### PR TITLE
Ensure ModLogger always emits warnings and errors

### DIFF
--- a/VeinWares.SubtleByte/Utilities/ModLogger.cs
+++ b/VeinWares.SubtleByte/Utilities/ModLogger.cs
@@ -20,14 +20,12 @@ namespace VeinWares.SubtleByte.Utilities
 
         public static void Warn(string message)
         {
-            if (Enabled)
-                Core.Log?.LogWarning(message);
+            Core.Log?.LogWarning(message);
         }
 
         public static void Error(string message)
         {
-            if (Enabled)
-                Core.Log?.LogError(message);
+            Core.Log?.LogError(message);
         }
     }
 }


### PR DESCRIPTION
## Summary
- update ModLogger so warnings and errors always log even when debug logs are disabled

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e8d61821288327ac0c54cb64334619