### PR TITLE
Introduce performance-first SubtleByte rewrite template

### DIFF
--- a/VeinWares.SubtleByte.sln
+++ b/VeinWares.SubtleByte.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.14.36121.58 d17.14
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VeinWares.SubtleByte", "VeinWares.SubtleByte\VeinWares.SubtleByte.csproj", "{0C8C4953-B36E-42DD-BE85-3D07B4CC7DCD}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VeinWares.SubtleByte", "VeinWares.SubtleByte\\VeinWares.SubtleByte.csproj", "{0C8C4953-B36E-42DD-BE85-3D07B4CC7DCD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SubtleByte.Template", "templates\\SubtleByte.Template\\SubtleByte.Template.csproj", "{C458EC06-2E99-4C18-953C-6A875F6CA5C9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{0C8C4953-B36E-42DD-BE85-3D07B4CC7DCD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0C8C4953-B36E-42DD-BE85-3D07B4CC7DCD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0C8C4953-B36E-42DD-BE85-3D07B4CC7DCD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C458EC06-2E99-4C18-953C-6A875F6CA5C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C458EC06-2E99-4C18-953C-6A875F6CA5C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C458EC06-2E99-4C18-953C-6A875F6CA5C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C458EC06-2E99-4C18-953C-6A875F6CA5C9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/performance-template.md
+++ b/docs/performance-template.md
@@ -1,0 +1,48 @@
+# SubtleByte Performance Template
+
+This template project lives in `templates/SubtleByte.Template` and provides a clean, modular
+starting point for rebuilding the SubtleByte mod with performance in mind. It keeps the
+existing production code untouched so you can experiment on a fresh branch while still
+referencing the old implementation.
+
+## Key ideas
+
+- **Server-only bootstrapping** – the plugin aborts immediately if it is accidentally
+  loaded on a client build, preventing unnecessary allocations.
+- **Module host** – features live in small `IModule` classes that can opt into the
+  lightweight `IUpdateModule` interface. Modules are created lazily from factories,
+  which keeps the template free from static singletons.
+- **Interval scheduler** – recurring jobs use `IntervalScheduler` rather than running
+  work inside `Update` every frame. This keeps the server’s hot loop clear.
+- **Performance tracker** – the `PerformanceTracker` wraps module initialization and
+  update calls and emits warnings whenever a module exceeds the configured budget
+  (5 ms by default). You can tighten or relax the threshold per module by creating
+  dedicated trackers.
+- **Unity host behaviour** – a minimal `ServerBehaviour` component drives the module
+  host. It is registered with `ClassInjector` so IL2CPP servers can instantiate it
+  without additional boilerplate.
+
+## Getting started on a new branch
+
+1. Create a new branch off `main` (for example `rewrite/perf-template`).
+2. Copy `templates/SubtleByte.Template` next to your new branch’s `VeinWares.SubtleByte`
+   project folder (or repoint the solution to the template project directly).
+3. Rename the namespace/package identifiers as needed (the template ships with
+   `veinwares.subtlebyte.template`).
+4. Add new modules in `templates/SubtleByte.Template/Modules`. Modules can request
+   scheduled work via `ModuleContext.Scheduler.Schedule` and patch Harmony hooks via
+   `ModuleContext.Harmony`.
+5. Once satisfied with the new layout, replace the original project references in the
+   `.sln` file or keep both projects side-by-side while you migrate functionality.
+
+## Extending the template
+
+- Implement `IDisposable` on modules to clean up Harmony patches or scheduled tasks.
+- Use `ModuleContext.Performance.Measure` when wrapping bespoke operations that are
+  not part of the module life-cycle.
+- Create thin feature modules (e.g., `BottleRefundModule`) that inject their own
+  configuration files instead of relying on global static configuration.
+
+This structure should keep high-frequency tasks contained and observable while you
+re-implement gameplay logic without inheriting the historical complexity that led to
+server slowdowns.

--- a/docs/subtlebyte-analysis.md
+++ b/docs/subtlebyte-analysis.md
@@ -1,0 +1,30 @@
+# SubtleByte update investigation
+
+## Summary of observed server behaviour
+- Unity reports missing components when loading persistence for prefab `-113436752` (`Snapshot_AbilityStateBuffer`, `AbilityJewelTemplate`, `AbilityCastCondition`, `BlobAssetOwner`, `AbilityGroupInfo`).
+- After players connect the server logs a large number of `Synced Float` / `Synced Integer` out-of-range warnings for health, attack speed, and ability slot indices.
+- The log also shows "JobTempAlloc" warnings, indicating that at least one system is allocating temporary native memory for longer than Unity's four-frame limit.
+
+## Root cause analysis
+
+### Prestige buff reapplication
+`PrestigeMini.ApplyLevel` re-applies a hijacked buff every time a player connects or their prestige file changes. Each call replaces the buff's `ModifyUnitStatBuff_DOTS` buffer with one entry per configured stat, using `ModificationId.NewId(0)` for every line.【F:VeinWares.SubtleByte/Services/PrestigeMini.cs†L41-L138】 The underlying `ModificationId` domain is globally incremented; once it exceeds 511 the resulting IDs are outside the replication range (0–511), leading to the ability slot warnings seen in the log.
+
+### Removal of ability-related components
+When the mod applies "permanent" buffs it strips several components from the live buff entity, including `ReplaceAbilityOnSlotBuff` and other ability/gameplay event components.【F:VeinWares.SubtleByte/Utilities/Buffs.cs†L34-L64】 If the original prefab expected these components, the server's persistence loader can no longer find them on the prefab entity, producing the repeated "Component ... is not found" errors when the save is loaded.
+
+### Lack of stat clamping
+SubtleByte's prestige configuration allows arbitrary additive and multiplicative bonuses with no server-side clamp.【F:VeinWares.SubtleByte/Config/SubtleBytePrestigeConfig.cs†L108-L158】 Large values (for example, health > 100k or attack speed multipliers > 4×) push synced attributes beyond the engine's allowed range, triggering the `Synced Float ... out of range` warnings.
+
+### Why the bottle-refund patch is not the culprit
+The newly-added blood homogenizer hook only inspects inventories and optionally adds a single Empty Bottle item when it detects a craft transition from `Mixing` to `NotReadyToMix`. The code never touches ability components, persistence, or player stats—it interacts solely with inventory buffers and cached `ItemData` structs.【F:VeinWares.SubtleByte/Patches/BloodMixerSystemsPatch.cs†L16-L196】 Because of that, it cannot emit the ability-related warnings that the server logs, and it does not allocate native memory that survives past the end of the frame (all temporary arrays and maps are disposed immediately). The warnings therefore have to come from the prestige systems above rather than the bottle refund logic.
+
+## Impact
+- The flood of replication warnings increases log volume and wastes CPU while the game engine repeatedly clamps invalid values.
+- Missing prefab components can prevent buffs/abilities from functioning correctly and may corrupt persistence data over time.
+
+## Recommendations
+1. Use deterministic `ModificationId` values (for example, reuse the same ID per stat) instead of continually calling `ModificationId.NewId(0)` every time the buff is refreshed.
+2. Avoid removing ability-related components from buff prefabs unless the replacement logic supplies an alternative; otherwise, guard the removal behind configuration so the original prefab structure is preserved.
+3. Introduce clamping/validation on prestige stat values before writing them into the buff to keep them within the engine's supported ranges (e.g., cap health ≤ 100,000 and attack speed multipliers ≤ 4).
+4. After applying these fixes, clear existing prestige buffs so the live entities pick up the corrected component layout and stat IDs.

--- a/templates/SubtleByte.Template/Infrastructure/Diagnostics/PerformanceTracker.cs
+++ b/templates/SubtleByte.Template/Infrastructure/Diagnostics/PerformanceTracker.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Diagnostics;
+using BepInEx.Logging;
+
+namespace VeinWares.SubtleByte.Template.Infrastructure.Diagnostics;
+
+public sealed class PerformanceTracker
+{
+    private readonly ManualLogSource _log;
+    private readonly double _thresholdMilliseconds;
+
+    public PerformanceTracker(ManualLogSource log, double thresholdMilliseconds)
+    {
+        _log = log;
+        _thresholdMilliseconds = Math.Max(0.1, thresholdMilliseconds);
+    }
+
+    public void Measure(string label, Action action)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        action();
+        stopwatch.Stop();
+
+        if (stopwatch.Elapsed.TotalMilliseconds > _thresholdMilliseconds)
+        {
+            _log.LogWarning($"[Perf] {label} took {stopwatch.Elapsed.TotalMilliseconds:F2} ms (threshold {_thresholdMilliseconds:F2} ms).");
+        }
+    }
+}

--- a/templates/SubtleByte.Template/Infrastructure/IModule.cs
+++ b/templates/SubtleByte.Template/Infrastructure/IModule.cs
@@ -1,0 +1,11 @@
+namespace VeinWares.SubtleByte.Template.Infrastructure;
+
+public interface IModule : System.IDisposable
+{
+    void Initialize(ModuleContext context);
+}
+
+public interface IUpdateModule
+{
+    void OnUpdate(float deltaTime);
+}

--- a/templates/SubtleByte.Template/Infrastructure/ModuleContext.cs
+++ b/templates/SubtleByte.Template/Infrastructure/ModuleContext.cs
@@ -1,0 +1,25 @@
+using BepInEx.Logging;
+using HarmonyLib;
+using VeinWares.SubtleByte.Template.Infrastructure.Diagnostics;
+using VeinWares.SubtleByte.Template.Runtime.Scheduling;
+
+namespace VeinWares.SubtleByte.Template.Infrastructure;
+
+public sealed class ModuleContext
+{
+    public ModuleContext(ManualLogSource log, IntervalScheduler scheduler, Harmony harmony, PerformanceTracker performanceTracker)
+    {
+        Log = log;
+        Scheduler = scheduler;
+        Harmony = harmony;
+        Performance = performanceTracker;
+    }
+
+    public ManualLogSource Log { get; }
+
+    public IntervalScheduler Scheduler { get; }
+
+    public Harmony Harmony { get; }
+
+    public PerformanceTracker Performance { get; }
+}

--- a/templates/SubtleByte.Template/Infrastructure/ModuleHost.cs
+++ b/templates/SubtleByte.Template/Infrastructure/ModuleHost.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using BepInEx.Logging;
+using HarmonyLib;
+using VeinWares.SubtleByte.Template.Infrastructure.Diagnostics;
+using VeinWares.SubtleByte.Template.Runtime.Scheduling;
+
+namespace VeinWares.SubtleByte.Template.Infrastructure;
+
+public sealed class ModuleHost : IDisposable
+{
+    private readonly ManualLogSource _log;
+    private readonly PerformanceTracker _performanceTracker;
+    private readonly IReadOnlyList<Func<IModule>> _moduleFactories;
+    private readonly List<IModule> _modules = new();
+    private readonly IntervalScheduler _scheduler = new();
+    private readonly List<IUpdateModule> _updateModules = new();
+    private readonly Harmony _harmony;
+
+    private ModuleHost(ManualLogSource log, PerformanceTracker performanceTracker, IReadOnlyList<Func<IModule>> moduleFactories,
+        Harmony harmony)
+    {
+        _log = log;
+        _performanceTracker = performanceTracker;
+        _moduleFactories = moduleFactories;
+        _harmony = harmony;
+    }
+
+    public int ModuleCount => _modules.Count;
+
+    public static ModuleHost Create(
+        ManualLogSource log,
+        PerformanceTracker performanceTracker,
+        IReadOnlyList<Func<IModule>> moduleFactories)
+    {
+        return new ModuleHost(log, performanceTracker, moduleFactories, new Harmony("veinwares.subtlebyte.template.modules"));
+    }
+
+    public void Initialize()
+    {
+        if (_modules.Count > 0)
+        {
+            _log.LogWarning("ModuleHost.Initialize called more than once. Ignoring subsequent invocation.");
+            return;
+        }
+
+        var context = new ModuleContext(_log, _scheduler, _harmony, _performanceTracker);
+
+        foreach (var factory in _moduleFactories)
+        {
+            IModule module;
+            try
+            {
+                module = factory();
+            }
+            catch (Exception ex)
+            {
+                _log.LogError($"Failed to create module from factory {factory.Method.DeclaringType?.FullName ?? "<unknown>"}: {ex}");
+                continue;
+            }
+
+            try
+            {
+                _performanceTracker.Measure(module.GetType().Name + ".Initialize", () => module.Initialize(context));
+                _modules.Add(module);
+                if (module is IUpdateModule updateModule)
+                {
+                    _updateModules.Add(updateModule);
+                }
+            }
+            catch (Exception ex)
+            {
+                _log.LogError($"Failed to initialize module {module.GetType().FullName}: {ex}");
+                module.Dispose();
+            }
+        }
+    }
+
+    public void Tick(float deltaTime)
+    {
+        _scheduler.Update(deltaTime);
+
+        foreach (var module in _updateModules)
+        {
+            var name = module.GetType().Name + ".Update";
+            try
+            {
+                _performanceTracker.Measure(name, () => module.OnUpdate(deltaTime));
+            }
+            catch (Exception ex)
+            {
+                _log.LogError($"Unhandled exception while ticking module {module.GetType().FullName}: {ex}");
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        for (var i = _modules.Count - 1; i >= 0; i--)
+        {
+            try
+            {
+                _modules[i].Dispose();
+            }
+            catch (Exception ex)
+            {
+                _log.LogError($"Module {_modules[i].GetType().FullName} threw during Dispose: {ex}");
+            }
+        }
+
+        _modules.Clear();
+        _updateModules.Clear();
+        _scheduler.Dispose();
+        _harmony.UnpatchSelf();
+    }
+}

--- a/templates/SubtleByte.Template/Modules/Core/HeartbeatModule.cs
+++ b/templates/SubtleByte.Template/Modules/Core/HeartbeatModule.cs
@@ -1,0 +1,29 @@
+using System;
+using VeinWares.SubtleByte.Template.Infrastructure;
+
+namespace VeinWares.SubtleByte.Template.Modules.Core;
+
+public sealed class HeartbeatModule : IModule
+{
+    private Runtime.Scheduling.IntervalScheduler.ScheduledHandle _handle;
+    private bool _disposed;
+
+    public void Initialize(ModuleContext context)
+    {
+        _handle = context.Scheduler.Schedule(TimeSpan.FromSeconds(30), () =>
+        {
+            context.Log.LogDebug("[Heartbeat] SubtleByte template host is running.");
+        }, runImmediately: true);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _handle.Dispose();
+        _disposed = true;
+    }
+}

--- a/templates/SubtleByte.Template/Plugin.cs
+++ b/templates/SubtleByte.Template/Plugin.cs
@@ -1,0 +1,56 @@
+using BepInEx;
+using BepInEx.Logging;
+using BepInEx.Unity.IL2CPP;
+using Il2CppInterop.Runtime.Injection;
+using UnityEngine;
+using VeinWares.SubtleByte.Template.Infrastructure;
+using VeinWares.SubtleByte.Template.Infrastructure.Diagnostics;
+using VeinWares.SubtleByte.Template.Modules.Core;
+using VeinWares.SubtleByte.Template.Runtime.Unity;
+
+namespace VeinWares.SubtleByte.Template;
+
+[BepInPlugin(PluginGuid, PluginName, PluginVersion)]
+[BepInDependency("gg.deca.VampireCommandFramework", BepInDependency.DependencyFlags.SoftDependency)]
+public sealed class Plugin : BasePlugin
+{
+    public const string PluginGuid = "veinwares.subtlebyte.template";
+    public const string PluginName = "SubtleByte Performance Template";
+    public const string PluginVersion = "0.0.1";
+
+    private ModuleHost? _moduleHost;
+    private ServerBootstrap? _bootstrap;
+
+    public override void Load()
+    {
+        if (Application.productName != "VRisingServer")
+        {
+            Log.LogWarning($"{PluginName} is designed for the dedicated server build. Skipping initialization for '{Application.productName}'.");
+            return;
+        }
+
+        ClassInjector.RegisterTypeInIl2Cpp<ServerBehaviour>();
+
+        var performanceTracker = new PerformanceTracker(Log, thresholdMilliseconds: 5.0);
+        _moduleHost = ModuleHost.Create(Log, performanceTracker, new[]
+        {
+            () => new HeartbeatModule(),
+        });
+
+        _moduleHost.Initialize();
+        _bootstrap = ServerBootstrap.Start(_moduleHost, Log);
+
+        Log.LogInfo($"{PluginName} {PluginVersion} initialized with {_moduleHost.ModuleCount} module(s).");
+    }
+
+    public override bool Unload()
+    {
+        _bootstrap?.Dispose();
+        _bootstrap = null;
+
+        _moduleHost?.Dispose();
+        _moduleHost = null;
+
+        return true;
+    }
+}

--- a/templates/SubtleByte.Template/Runtime/Scheduling/IntervalScheduler.cs
+++ b/templates/SubtleByte.Template/Runtime/Scheduling/IntervalScheduler.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+
+namespace VeinWares.SubtleByte.Template.Runtime.Scheduling;
+
+public sealed class IntervalScheduler : IDisposable
+{
+    private readonly List<ScheduledAction> _actions = new();
+    private bool _disposed;
+    private int _nextId = 1;
+
+    public ScheduledHandle Schedule(TimeSpan interval, Action action, bool runImmediately = false)
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(nameof(IntervalScheduler));
+        }
+
+        if (interval <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(interval), "Interval must be positive.");
+        }
+
+        if (action is null)
+        {
+            throw new ArgumentNullException(nameof(action));
+        }
+
+        var scheduled = new ScheduledAction(_nextId++, interval, action, runImmediately);
+        _actions.Add(scheduled);
+        return new ScheduledHandle(this, scheduled.Id);
+    }
+
+    public void Update(float deltaTime)
+    {
+        if (_disposed || _actions.Count == 0)
+        {
+            return;
+        }
+
+        var delta = TimeSpan.FromSeconds(Math.Max(0f, deltaTime));
+
+        for (var index = 0; index < _actions.Count; index++)
+        {
+            var entry = _actions[index];
+            if (!entry.IsActive)
+            {
+                continue;
+            }
+
+            entry.Accumulator += delta;
+            if (entry.RunImmediately)
+            {
+                entry.RunImmediately = false;
+                SafeInvoke(entry.Callback);
+                entry.Accumulator = TimeSpan.Zero;
+            }
+            else if (entry.Accumulator >= entry.Interval)
+            {
+                entry.Accumulator -= entry.Interval;
+                SafeInvoke(entry.Callback);
+            }
+
+            _actions[index] = entry;
+        }
+
+        _actions.RemoveAll(static action => !action.IsActive);
+    }
+
+    public void Cancel(int id)
+    {
+        for (var index = 0; index < _actions.Count; index++)
+        {
+            if (_actions[index].Id == id)
+            {
+                var entry = _actions[index];
+                entry.IsActive = false;
+                _actions[index] = entry;
+                break;
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        _disposed = true;
+        _actions.Clear();
+    }
+
+    private static readonly BepInEx.Logging.ManualLogSource SchedulerLog =
+        BepInEx.Logging.Logger.CreateLogSource("SubtleByte.Template.Scheduler");
+
+    private static void SafeInvoke(Action callback)
+    {
+        try
+        {
+            callback();
+        }
+        catch (Exception ex)
+        {
+            SchedulerLog.LogError($"Scheduled action threw: {ex}");
+        }
+    }
+
+    private struct ScheduledAction
+    {
+        public ScheduledAction(int id, TimeSpan interval, Action callback, bool runImmediately)
+        {
+            Id = id;
+            Interval = interval;
+            Callback = callback;
+            RunImmediately = runImmediately;
+            Accumulator = TimeSpan.Zero;
+            IsActive = true;
+        }
+
+        public int Id { get; }
+        public TimeSpan Interval { get; }
+        public Action Callback { get; }
+        public bool RunImmediately { get; set; }
+        public TimeSpan Accumulator { get; set; }
+        public bool IsActive { get; set; }
+    }
+
+    public readonly struct ScheduledHandle : IDisposable
+    {
+        private readonly IntervalScheduler? _scheduler;
+        private readonly int _id;
+
+        internal ScheduledHandle(IntervalScheduler scheduler, int id)
+        {
+            _scheduler = scheduler;
+            _id = id;
+        }
+
+        public void Dispose()
+        {
+            _scheduler?.Cancel(_id);
+        }
+    }
+}

--- a/templates/SubtleByte.Template/Runtime/Unity/ServerBehaviour.cs
+++ b/templates/SubtleByte.Template/Runtime/Unity/ServerBehaviour.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+using VeinWares.SubtleByte.Template.Infrastructure;
+
+namespace VeinWares.SubtleByte.Template.Runtime.Unity;
+
+public sealed class ServerBehaviour : MonoBehaviour
+{
+    private ModuleHost? _host;
+
+    internal void Bind(ModuleHost host)
+    {
+        _host = host;
+    }
+
+    private void Update()
+    {
+        if (_host is null)
+        {
+            return;
+        }
+
+        _host.Tick(Time.deltaTime);
+    }
+}

--- a/templates/SubtleByte.Template/Runtime/Unity/ServerBootstrap.cs
+++ b/templates/SubtleByte.Template/Runtime/Unity/ServerBootstrap.cs
@@ -1,0 +1,52 @@
+using System;
+using BepInEx.Logging;
+using UnityEngine;
+using VeinWares.SubtleByte.Template.Infrastructure;
+
+namespace VeinWares.SubtleByte.Template.Runtime.Unity;
+
+public sealed class ServerBootstrap : IDisposable
+{
+    private readonly ManualLogSource _log;
+    private readonly ModuleHost _host;
+    private readonly GameObject _root;
+    private readonly ServerBehaviour _behaviour;
+
+    private ServerBootstrap(ModuleHost host, GameObject root, ServerBehaviour behaviour, ManualLogSource log)
+    {
+        _host = host;
+        _root = root;
+        _behaviour = behaviour;
+        _log = log;
+    }
+
+    public static ServerBootstrap Start(ModuleHost host, ManualLogSource log)
+    {
+        var go = new GameObject("SubtleByte.ModuleHost");
+        UnityEngine.Object.DontDestroyOnLoad(go);
+        var behaviour = go.AddComponent<ServerBehaviour>();
+        behaviour.Bind(host);
+        log.LogDebug("ServerBootstrap created persistent host GameObject.");
+        return new ServerBootstrap(host, go, behaviour, log);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (_behaviour != null)
+            {
+                _behaviour.enabled = false;
+            }
+
+            if (_root != null)
+            {
+                UnityEngine.Object.Destroy(_root);
+            }
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning($"Failed to clean up ServerBootstrap GameObject: {ex}");
+        }
+    }
+}

--- a/templates/SubtleByte.Template/SubtleByte.Template.csproj
+++ b/templates/SubtleByte.Template/SubtleByte.Template.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <AssemblyName>VeinWares.SubtleByte.Template</AssemblyName>
+    <RootNamespace>VeinWares.SubtleByte.Template</RootNamespace>
+    <LangVersion>latest</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Description>Performance-first template for rebuilding the SubtleByte mod on V Rising dedicated servers.</Description>
+    <Version>0.0.1</Version>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="BepInEx.Core" Version="6.0.0-be.733" IncludeAssets="compile" />
+    <PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be.733" IncludeAssets="compile" />
+    <PackageReference Include="BepInEx.PluginInfoProps" Version="2.1.0" />
+    <PackageReference Include="HarmonyLib" Version="2.3.3" IncludeAssets="compile" />
+    <PackageReference Include="VRising.Unhollowed.Client" Version="1.1.*" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add a new `SubtleByte.Template` project that boots a module host with performance tracking, interval scheduling, and Unity lifecycle bindings for headless servers
- document how to spin up a clean performance-focused rewrite branch using the template
- register the template project in the solution so it can be built alongside the existing mod

## Testing
- `dotnet build templates/SubtleByte.Template/SubtleByte.Template.csproj -warnaserror` *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e8d5e132f0832790191b0fd9f7ca6e