### PR TITLE
Add wanted system scaffolding and persistence

### DIFF
--- a/VeinWares.SubtleByte/Config/SubtleBytePluginConfig.cs
+++ b/VeinWares.SubtleByte/Config/SubtleBytePluginConfig.cs
@@ -12,12 +12,14 @@ namespace VeinWares.SubtleByte.Config
         private static ConfigEntry<bool> _relicDebugEventsEnabled;
         private static ConfigEntry<bool> _itemStackServiceEnabled;
         private static ConfigEntry<bool> _debugLogsEnabled;
+        private static ConfigEntry<bool> _wantedSystemEnabled;
 
         public static bool EmptyBottleRefundEnabled => _emptyBottleRefundEnabled?.Value ?? true;
         internal static ConfigEntry<bool> EmptyBottleRefundEnabledEntry => _emptyBottleRefundEnabled;
         public static bool RelicDebugEventsEnabled => _relicDebugEventsEnabled?.Value ?? true;
         public static bool ItemStackServiceEnabled => _itemStackServiceEnabled?.Value ?? true;
         public static bool DebugLogsEnabled => _debugLogsEnabled?.Value ?? false;
+        public static bool WantedSystemEnabled => _wantedSystemEnabled?.Value ?? false;
 
         public static void Initialize()
         {
@@ -50,6 +52,14 @@ namespace VeinWares.SubtleByte.Config
                 "Enable Debug Logs",
                 false,
                 "When true, SubtleByte emits all diagnostic log messages. Set to false to silence the mod's logging entirely.");
+
+            _wantedSystemEnabled = _configFile.Bind(
+                "Wanted System",
+                "Enable Wanted System",
+                false,
+                "Master toggle for the Wanted gameplay system. When disabled, the wanted modules, commands, and persistence are not initialised.");
+
+            WantedConfig.Initialize(_configFile);
         }
 
         public static void SetDebugLogs(bool enabled)
@@ -61,5 +71,7 @@ namespace VeinWares.SubtleByte.Config
             _debugLogsEnabled.Value = enabled;
             _configFile?.Save();
         }
+
+        internal static ConfigEntry<bool> WantedSystemEnabledEntry => _wantedSystemEnabled;
     }
 }

--- a/VeinWares.SubtleByte/Config/WantedConfig.cs
+++ b/VeinWares.SubtleByte/Config/WantedConfig.cs
@@ -1,0 +1,178 @@
+using System;
+using BepInEx.Configuration;
+
+namespace VeinWares.SubtleByte.Config;
+
+internal static class WantedConfig
+{
+    private static bool _initialized;
+    private static ConfigEntry<bool> _ambushesEnabled;
+    private static ConfigEntry<float> _heatGainMultiplier;
+    private static ConfigEntry<float> _heatDecayPerMinute;
+    private static ConfigEntry<float> _cooldownGraceSeconds;
+    private static ConfigEntry<float> _combatCooldownSeconds;
+    private static ConfigEntry<float> _ambushCooldownMinutes;
+    private static ConfigEntry<float> _minimumAmbushHeat;
+    private static ConfigEntry<int> _maximumHeat;
+    private static ConfigEntry<int> _autosaveMinutes;
+    private static ConfigEntry<int> _autosaveBackups;
+
+    public static void Initialize(ConfigFile configFile)
+    {
+        if (_initialized)
+        {
+            return;
+        }
+
+        if (configFile is null)
+        {
+            throw new ArgumentNullException(nameof(configFile));
+        }
+
+        _ambushesEnabled = configFile.Bind(
+            "Wanted System",
+            "Enable Ambush Spawns",
+            true,
+            "Controls whether the wanted system is allowed to spawn ambush squads when player heat crosses the configured threshold.");
+
+        _heatGainMultiplier = configFile.Bind(
+            "Wanted System",
+            "Heat Gain Multiplier",
+            1.0f,
+            "Scales the amount of heat granted per qualifying kill. Values below zero will be clamped to zero.");
+
+        _heatDecayPerMinute = configFile.Bind(
+            "Wanted System",
+            "Heat Decay Per Minute",
+            10.0f,
+            "Amount of heat removed from every active faction bucket each minute while the player is eligible for cooldown.");
+
+        _cooldownGraceSeconds = configFile.Bind(
+            "Wanted System",
+            "Cooldown Grace Seconds",
+            30.0f,
+            "How long after combat the player must remain idle before their heat begins to decay.");
+
+        _combatCooldownSeconds = configFile.Bind(
+            "Wanted System",
+            "Combat Cooldown Seconds",
+            15.0f,
+            "Minimum time between combat triggers that will reset the heat decay timer.");
+
+        _ambushCooldownMinutes = configFile.Bind(
+            "Wanted System",
+            "Ambush Cooldown Minutes",
+            15.0f,
+            "Minimum number of minutes that must pass before the same player can be ambushed again.");
+
+        _minimumAmbushHeat = configFile.Bind(
+            "Wanted System",
+            "Minimum Ambush Heat",
+            50.0f,
+            "Players must reach this heat level (after multipliers) before ambush squads are considered.");
+
+        _maximumHeat = configFile.Bind(
+            "Wanted System",
+            "Maximum Heat",
+            300,
+            "Upper bound for heat per faction. Any calculated heat beyond this value will be clamped.");
+
+        _autosaveMinutes = configFile.Bind(
+            "Wanted System",
+            "Autosave Minutes",
+            5,
+            "Interval, in minutes, for persisting wanted heat data to disk. Minimum of one minute.");
+
+        _autosaveBackups = configFile.Bind(
+            "Wanted System",
+            "Autosave Backups",
+            3,
+            "Number of rolling backup files to keep whenever the wanted system saves the heat database.");
+
+        ClampValues();
+
+        _initialized = true;
+    }
+
+    public static WantedConfigSnapshot CreateSnapshot()
+    {
+        if (!_initialized)
+        {
+            throw new InvalidOperationException("WantedConfig.Initialize must be called before creating a snapshot.");
+        }
+
+        ClampValues();
+
+        return new WantedConfigSnapshot(
+            _ambushesEnabled.Value,
+            MathF.Max(0f, _heatGainMultiplier.Value),
+            MathF.Max(0f, _heatDecayPerMinute.Value) / 60f,
+            TimeSpan.FromSeconds(MathF.Max(0f, _cooldownGraceSeconds.Value)),
+            TimeSpan.FromSeconds(MathF.Max(1f, _combatCooldownSeconds.Value)),
+            TimeSpan.FromMinutes(MathF.Max(1f, _ambushCooldownMinutes.Value)),
+            MathF.Max(0f, _minimumAmbushHeat.Value),
+            Math.Max(1, _maximumHeat.Value),
+            TimeSpan.FromMinutes(Math.Max(1, _autosaveMinutes.Value)),
+            Math.Clamp(_autosaveBackups.Value, 0, 20));
+    }
+
+    private static void ClampValues()
+    {
+        if (_heatGainMultiplier.Value < 0f)
+        {
+            _heatGainMultiplier.Value = 0f;
+        }
+
+        if (_heatDecayPerMinute.Value < 0f)
+        {
+            _heatDecayPerMinute.Value = 0f;
+        }
+
+        if (_cooldownGraceSeconds.Value < 0f)
+        {
+            _cooldownGraceSeconds.Value = 0f;
+        }
+
+        if (_combatCooldownSeconds.Value < 1f)
+        {
+            _combatCooldownSeconds.Value = 1f;
+        }
+
+        if (_ambushCooldownMinutes.Value < 1f)
+        {
+            _ambushCooldownMinutes.Value = 1f;
+        }
+
+        if (_minimumAmbushHeat.Value < 0f)
+        {
+            _minimumAmbushHeat.Value = 0f;
+        }
+
+        if (_maximumHeat.Value < 1)
+        {
+            _maximumHeat.Value = 1;
+        }
+
+        if (_autosaveMinutes.Value < 1)
+        {
+            _autosaveMinutes.Value = 1;
+        }
+
+        if (_autosaveBackups.Value < 0)
+        {
+            _autosaveBackups.Value = 0;
+        }
+    }
+}
+
+internal readonly record struct WantedConfigSnapshot(
+    bool AmbushesEnabled,
+    float HeatGainMultiplier,
+    float HeatDecayPerSecond,
+    TimeSpan CooldownGrace,
+    TimeSpan CombatCooldown,
+    TimeSpan AmbushCooldown,
+    float MinimumAmbushHeat,
+    int MaximumHeat,
+    TimeSpan AutosaveInterval,
+    int AutosaveBackupCount);

--- a/VeinWares.SubtleByte/Infrastructure/ModuleConfig.cs
+++ b/VeinWares.SubtleByte/Infrastructure/ModuleConfig.cs
@@ -5,10 +5,15 @@ namespace VeinWares.SubtleByte.Infrastructure;
 
 public sealed class ModuleConfig
 {
-    public ModuleConfig(ConfigEntry<bool> bottleRefundEnabled)
+    public ModuleConfig(
+        ConfigEntry<bool> bottleRefundEnabled,
+        ConfigEntry<bool> wantedSystemEnabled)
     {
         BottleRefundEnabled = bottleRefundEnabled ?? throw new ArgumentNullException(nameof(bottleRefundEnabled));
+        WantedSystemEnabled = wantedSystemEnabled ?? throw new ArgumentNullException(nameof(wantedSystemEnabled));
     }
 
     public ConfigEntry<bool> BottleRefundEnabled { get; }
+
+    public ConfigEntry<bool> WantedSystemEnabled { get; }
 }

--- a/VeinWares.SubtleByte/Models/Wanted/PlayerHeatData.cs
+++ b/VeinWares.SubtleByte/Models/Wanted/PlayerHeatData.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using VeinWares.SubtleByte.Utilities;
+
+namespace VeinWares.SubtleByte.Models.Wanted;
+
+internal sealed class PlayerHeatData
+{
+    private readonly LazyDictionary<string, HeatEntry> _factionHeat = new(() => new HeatEntry());
+
+    public DateTime LastCombatStart { get; set; }
+
+    public DateTime LastCombatEnd { get; set; }
+
+    public IReadOnlyDictionary<string, HeatEntry> FactionHeat => _factionHeat.AsReadOnly();
+
+    public HeatEntry GetHeat(string factionId) => _factionHeat[factionId];
+
+    public void SetHeat(string factionId, HeatEntry entry)
+    {
+        _factionHeat[factionId] = entry;
+    }
+
+    public bool ClearFaction(string factionId)
+    {
+        return _factionHeat.Remove(factionId);
+    }
+
+    public Dictionary<string, HeatEntry> ExportSnapshot()
+    {
+        var result = new Dictionary<string, HeatEntry>(_factionHeat.Count);
+        foreach (var pair in _factionHeat)
+        {
+            result[pair.Key] = pair.Value;
+        }
+
+        return result;
+    }
+
+    public bool RunCooldown(float decayPerSecond, float deltaSeconds, float removalThreshold)
+    {
+        if (_factionHeat.Count == 0 || decayPerSecond <= 0f || deltaSeconds <= 0f)
+        {
+            return false;
+        }
+
+        var toRemove = new List<string>();
+        var changed = false;
+        var decayAmount = decayPerSecond * deltaSeconds;
+
+        foreach (var pair in _factionHeat)
+        {
+            var entry = pair.Value;
+            if (entry.Heat <= 0f)
+            {
+                if (entry.Heat <= removalThreshold)
+                {
+                    toRemove.Add(pair.Key);
+                }
+
+                continue;
+            }
+
+            var newHeat = MathF.Max(0f, entry.Heat - decayAmount);
+            if (MathF.Abs(newHeat - entry.Heat) > 0.001f)
+            {
+                changed = true;
+            }
+
+            entry.Heat = newHeat;
+            entry.LastUpdated = DateTime.UtcNow;
+            _factionHeat[pair.Key] = entry;
+
+            if (newHeat <= removalThreshold)
+            {
+                toRemove.Add(pair.Key);
+            }
+        }
+
+        foreach (var faction in toRemove)
+        {
+            _factionHeat.Remove(faction);
+            changed = true;
+        }
+
+        return changed;
+    }
+}
+
+internal struct HeatEntry
+{
+    public float Heat { get; set; }
+
+    public DateTime LastUpdated { get; set; }
+
+    public DateTime LastAmbush { get; set; }
+}

--- a/VeinWares.SubtleByte/Modules/Wanted/WantedModule.cs
+++ b/VeinWares.SubtleByte/Modules/Wanted/WantedModule.cs
@@ -1,0 +1,71 @@
+using System;
+using VeinWares.SubtleByte.Config;
+using VeinWares.SubtleByte.Infrastructure;
+using VeinWares.SubtleByte.Services.Wanted;
+
+namespace VeinWares.SubtleByte.Modules.Wanted;
+
+internal sealed class WantedModule : IModule, IUpdateModule
+{
+    private bool _enabled;
+    private bool _disposed;
+    private Runtime.Scheduling.IntervalScheduler.ScheduledHandle _autosaveHandle;
+    private bool _autosaveRegistered;
+
+    public void Initialize(ModuleContext context)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        _enabled = context.Config.WantedSystemEnabled.Value && SubtleBytePluginConfig.WantedSystemEnabled;
+        if (!_enabled)
+        {
+            context.Log.LogInfo("[Wanted] Wanted system disabled via configuration.");
+            return;
+        }
+
+        var snapshot = WantedConfig.CreateSnapshot();
+        WantedSystem.Initialize(snapshot, context.Log);
+
+        _autosaveHandle = context.Scheduler.Schedule(
+            snapshot.AutosaveInterval,
+            WantedSystem.FlushPersistence,
+            runImmediately: false);
+        _autosaveRegistered = true;
+
+        context.Log.LogInfo("[Wanted] Wanted module initialised.");
+    }
+
+    public void OnUpdate(float deltaTime)
+    {
+        if (!_enabled || _disposed)
+        {
+            return;
+        }
+
+        WantedSystem.Tick(deltaTime);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        if (_autosaveRegistered)
+        {
+            _autosaveHandle.Dispose();
+        }
+
+        if (_enabled)
+        {
+            WantedSystem.FlushPersistence();
+            WantedSystem.Shutdown();
+        }
+
+        _disposed = true;
+    }
+}

--- a/VeinWares.SubtleByte/Plugin.cs
+++ b/VeinWares.SubtleByte/Plugin.cs
@@ -15,6 +15,7 @@ using VeinWares.SubtleByte.Modules.Crafting;
 using VeinWares.SubtleByte.Runtime.Unity;
 using VeinWares.SubtleByte.Services;
 using VeinWares.SubtleByte.Utilities;
+using VeinWares.SubtleByte.Modules.Wanted;
 
 namespace VeinWares.SubtleByte
 {
@@ -46,11 +47,14 @@ namespace VeinWares.SubtleByte
 
             var performanceLogPath = Path.Combine(Paths.ConfigPath, "VeinWares SubtleByte", "performance.log");
             var performanceTracker = new PerformanceTracker(Log, thresholdMilliseconds: 5.0, performanceLogPath);
-            var moduleConfig = new ModuleConfig(SubtleBytePluginConfig.EmptyBottleRefundEnabledEntry);
+            var moduleConfig = new ModuleConfig(
+                SubtleBytePluginConfig.EmptyBottleRefundEnabledEntry,
+                SubtleBytePluginConfig.WantedSystemEnabledEntry);
             _moduleHost = ModuleHost.Create(Log, performanceTracker, new Func<IModule>[]
             {
                 () => new HeartbeatModule(),
                 () => new BottleRefundModule(),
+                () => new WantedModule(),
             }, moduleConfig);
 
             _moduleHost.Initialize();

--- a/VeinWares.SubtleByte/Services/Wanted/WantedPersistence.cs
+++ b/VeinWares.SubtleByte/Services/Wanted/WantedPersistence.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using BepInEx;
+using VeinWares.SubtleByte.Models.Wanted;
+using VeinWares.SubtleByte.Utilities;
+
+namespace VeinWares.SubtleByte.Services.Wanted;
+
+internal static class WantedPersistence
+{
+    private static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true
+    };
+
+    private static string ConfigDirectory => Path.Combine(Paths.ConfigPath, "VeinWares SubtleByte");
+    private static string SavePath => Path.Combine(ConfigDirectory, "playerWantedLevel.json");
+
+    public static Dictionary<ulong, PlayerHeatData> Load()
+    {
+        try
+        {
+            if (!File.Exists(SavePath))
+            {
+                return new Dictionary<ulong, PlayerHeatData>();
+            }
+
+            var json = File.ReadAllText(SavePath);
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return new Dictionary<ulong, PlayerHeatData>();
+            }
+
+            var payload = JsonSerializer.Deserialize<Dictionary<string, PlayerHeatRecord>>(json, Options);
+            if (payload is null)
+            {
+                return new Dictionary<ulong, PlayerHeatData>();
+            }
+
+            return payload
+                .Select(static pair => new KeyValuePair<ulong, PlayerHeatData>(
+                    ulong.TryParse(pair.Key, out var steamId) ? steamId : 0,
+                    FromRecord(pair.Value)))
+                .Where(static pair => pair.Key != 0)
+                .ToDictionary(static pair => pair.Key, static pair => pair.Value);
+        }
+        catch (Exception ex)
+        {
+            ModLogger.Error($"[WantedPersistence] Failed to load heat data: {ex.Message}");
+            return new Dictionary<ulong, PlayerHeatData>();
+        }
+    }
+
+    public static void Save(Dictionary<string, PlayerHeatRecord> snapshot, int backupCount)
+    {
+        if (snapshot is null)
+        {
+            throw new ArgumentNullException(nameof(snapshot));
+        }
+
+        try
+        {
+            Directory.CreateDirectory(ConfigDirectory);
+
+            if (File.Exists(SavePath) && backupCount > 0)
+            {
+                CreateRollingBackups(backupCount);
+            }
+
+            var json = JsonSerializer.Serialize(snapshot, Options);
+            File.WriteAllText(SavePath, json);
+        }
+        catch (Exception ex)
+        {
+            ModLogger.Error($"[WantedPersistence] Failed to save heat data: {ex.Message}");
+        }
+    }
+
+    private static PlayerHeatData FromRecord(PlayerHeatRecord record)
+    {
+        var data = new PlayerHeatData
+        {
+            LastCombatStart = record.LastCombatStart,
+            LastCombatEnd = record.LastCombatEnd
+        };
+
+        if (record.Factions is null)
+        {
+            return data;
+        }
+
+        foreach (var faction in record.Factions)
+        {
+            var entry = new HeatEntry
+            {
+                Heat = faction.Value.Heat,
+                LastAmbush = faction.Value.LastAmbush,
+                LastUpdated = faction.Value.LastUpdated
+            };
+            data.SetHeat(faction.Key, entry);
+        }
+
+        return data;
+    }
+
+    private static void CreateRollingBackups(int backupCount)
+    {
+        try
+        {
+            for (var index = backupCount - 1; index >= 0; index--)
+            {
+                var source = index == 0 ? SavePath : GetBackupPath(index - 1);
+                var destination = GetBackupPath(index);
+
+                if (File.Exists(source))
+                {
+                    File.Copy(source, destination, overwrite: true);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            ModLogger.Warn($"[WantedPersistence] Failed to rotate backups: {ex.Message}");
+        }
+    }
+
+    private static string GetBackupPath(int index)
+    {
+        var suffix = index.ToString().PadLeft(2, '0');
+        var fileName = $"playerWantedLevel.json.bak{suffix}";
+        return Path.Combine(ConfigDirectory, fileName);
+    }
+}
+
+internal sealed class PlayerHeatRecord
+{
+    public Dictionary<string, HeatEntryRecord> Factions { get; set; } = new();
+
+    public DateTime LastCombatStart { get; set; }
+
+    public DateTime LastCombatEnd { get; set; }
+}
+
+internal sealed class HeatEntryRecord
+{
+    public float Heat { get; set; }
+
+    public DateTime LastUpdated { get; set; }
+
+    public DateTime LastAmbush { get; set; }
+}

--- a/VeinWares.SubtleByte/Services/Wanted/WantedSystem.cs
+++ b/VeinWares.SubtleByte/Services/Wanted/WantedSystem.cs
@@ -1,0 +1,247 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using BepInEx.Logging;
+using VeinWares.SubtleByte.Config;
+using VeinWares.SubtleByte.Models.Wanted;
+
+namespace VeinWares.SubtleByte.Services.Wanted;
+
+internal static class WantedSystem
+{
+    private static readonly ConcurrentDictionary<ulong, PlayerHeatData> PlayerHeat = new();
+    private static ManualLogSource? _log;
+    private static WantedConfigSnapshot _config;
+    private static bool _initialized;
+    private static bool _dirty;
+
+    public static bool Enabled => _initialized;
+
+    public static int AutosaveBackupCount { get; private set; }
+
+    public static void Initialize(WantedConfigSnapshot config, ManualLogSource log)
+    {
+        if (log is null)
+        {
+            throw new ArgumentNullException(nameof(log));
+        }
+
+        _log = log;
+        _config = config;
+        AutosaveBackupCount = config.AutosaveBackupCount;
+
+        PlayerHeat.Clear();
+        var loaded = WantedPersistence.Load();
+        foreach (var pair in loaded)
+        {
+            PlayerHeat[pair.Key] = pair.Value;
+        }
+
+        _dirty = false;
+        _initialized = true;
+        _log.LogInfo("[Wanted] Wanted system initialised.");
+    }
+
+    public static void Shutdown()
+    {
+        if (!_initialized)
+        {
+            return;
+        }
+
+        FlushPersistence();
+        PlayerHeat.Clear();
+        _initialized = false;
+        _log?.LogInfo("[Wanted] Wanted system shut down.");
+    }
+
+    public static void Tick(float deltaTime)
+    {
+        if (!_initialized || deltaTime <= 0f)
+        {
+            return;
+        }
+
+        if (_config.HeatDecayPerSecond <= 0f)
+        {
+            return;
+        }
+
+        var now = DateTime.UtcNow;
+        var removalThreshold = 0.01f;
+
+        foreach (var pair in PlayerHeat)
+        {
+            var data = pair.Value;
+            if (!IsEligibleForCooldown(data, now))
+            {
+                continue;
+            }
+
+            if (data.RunCooldown(_config.HeatDecayPerSecond, deltaTime, removalThreshold))
+            {
+                _dirty = true;
+            }
+        }
+    }
+
+    public static void RegisterHeatGain(ulong steamId, string factionId, float baseHeat)
+    {
+        if (!_initialized || string.IsNullOrWhiteSpace(factionId) || baseHeat <= 0f)
+        {
+            return;
+        }
+
+        var adjusted = baseHeat * _config.HeatGainMultiplier;
+        var data = PlayerHeat.GetOrAdd(steamId, static _ => new PlayerHeatData());
+        var entry = data.GetHeat(factionId);
+        var newHeat = MathF.Clamp(entry.Heat + adjusted, 0f, _config.MaximumHeat);
+        entry.Heat = newHeat;
+        entry.LastUpdated = DateTime.UtcNow;
+        data.SetHeat(factionId, entry);
+        _dirty = true;
+    }
+
+    public static void RegisterDeath(ulong steamId)
+    {
+        if (!_initialized)
+        {
+            return;
+        }
+
+        if (PlayerHeat.TryRemove(steamId, out _))
+        {
+            _dirty = true;
+        }
+    }
+
+    public static void RegisterCombatStart(ulong steamId)
+    {
+        if (!_initialized)
+        {
+            return;
+        }
+
+        var data = PlayerHeat.GetOrAdd(steamId, static _ => new PlayerHeatData());
+        data.LastCombatStart = DateTime.UtcNow;
+    }
+
+    public static void RegisterCombatEnd(ulong steamId)
+    {
+        if (!_initialized)
+        {
+            return;
+        }
+
+        if (!PlayerHeat.TryGetValue(steamId, out var data))
+        {
+            return;
+        }
+
+        data.LastCombatEnd = DateTime.UtcNow;
+    }
+
+    public static void RegisterAmbush(ulong steamId, string factionId)
+    {
+        if (!_initialized || string.IsNullOrWhiteSpace(factionId))
+        {
+            return;
+        }
+
+        var data = PlayerHeat.GetOrAdd(steamId, static _ => new PlayerHeatData());
+        var entry = data.GetHeat(factionId);
+        entry.LastAmbush = DateTime.UtcNow;
+        data.SetHeat(factionId, entry);
+        _dirty = true;
+    }
+
+    public static bool TryGetPlayerHeat(ulong steamId, out WantedPlayerSnapshot snapshot)
+    {
+        if (!_initialized)
+        {
+            snapshot = new WantedPlayerSnapshot(steamId, new Dictionary<string, HeatEntry>(), DateTime.MinValue, DateTime.MinValue);
+            return false;
+        }
+
+        if (PlayerHeat.TryGetValue(steamId, out var data))
+        {
+            snapshot = new WantedPlayerSnapshot(steamId, data.ExportSnapshot(), data.LastCombatStart, data.LastCombatEnd);
+            return true;
+        }
+
+        snapshot = new WantedPlayerSnapshot(steamId, new Dictionary<string, HeatEntry>(), DateTime.MinValue, DateTime.MinValue);
+        return false;
+    }
+
+    public static void ClearPlayerHeat(ulong steamId)
+    {
+        if (!_initialized)
+        {
+            return;
+        }
+
+        if (PlayerHeat.TryRemove(steamId, out _))
+        {
+            _dirty = true;
+        }
+    }
+
+    public static void FlushPersistence()
+    {
+        if (!_initialized || !_dirty)
+        {
+            return;
+        }
+
+        try
+        {
+            var snapshot = CreateSerializableSnapshot();
+            WantedPersistence.Save(snapshot, AutosaveBackupCount);
+            _dirty = false;
+        }
+        catch (Exception ex)
+        {
+            _log?.LogError($"[Wanted] Failed to flush wanted persistence: {ex.Message}");
+        }
+    }
+
+    private static bool IsEligibleForCooldown(PlayerHeatData data, DateTime now)
+    {
+        if (data.LastCombatEnd == DateTime.MinValue)
+        {
+            return true;
+        }
+
+        var elapsed = now - data.LastCombatEnd;
+        return elapsed >= _config.CooldownGrace;
+    }
+
+    private static Dictionary<string, PlayerHeatRecord> CreateSerializableSnapshot()
+    {
+        return PlayerHeat
+            .Where(static pair => pair.Value.FactionHeat.Count > 0)
+            .ToDictionary(
+                static pair => pair.Key.ToString(),
+                static pair => new PlayerHeatRecord
+                {
+                    LastCombatStart = pair.Value.LastCombatStart,
+                    LastCombatEnd = pair.Value.LastCombatEnd,
+                    Factions = pair.Value.ExportSnapshot()
+                        .ToDictionary(
+                            static faction => faction.Key,
+                            static faction => new HeatEntryRecord
+                            {
+                                Heat = faction.Value.Heat,
+                                LastAmbush = faction.Value.LastAmbush,
+                                LastUpdated = faction.Value.LastUpdated
+                            })
+                });
+    }
+}
+
+internal readonly record struct WantedPlayerSnapshot(
+    ulong SteamId,
+    IReadOnlyDictionary<string, HeatEntry> HeatByFaction,
+    DateTime LastCombatStart,
+    DateTime LastCombatEnd);

--- a/VeinWares.SubtleByte/Utilities/LazyDictionary.cs
+++ b/VeinWares.SubtleByte/Utilities/LazyDictionary.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace VeinWares.SubtleByte.Utilities;
+
+internal sealed class LazyDictionary<TKey, TValue> : IEnumerable<KeyValuePair<TKey, TValue>> where TKey : notnull
+{
+    private readonly Func<TValue> _factory;
+    private readonly Dictionary<TKey, TValue> _inner;
+
+    public LazyDictionary(Func<TValue> factory)
+    {
+        _factory = factory ?? throw new ArgumentNullException(nameof(factory));
+        _inner = new Dictionary<TKey, TValue>();
+    }
+
+    public TValue this[TKey key]
+    {
+        get
+        {
+            if (!_inner.TryGetValue(key, out var value))
+            {
+                value = _factory();
+                _inner[key] = value;
+            }
+
+            return value;
+        }
+        set => _inner[key] = value;
+    }
+
+    public int Count => _inner.Count;
+
+    public bool Remove(TKey key) => _inner.Remove(key);
+
+    public bool TryGetValue(TKey key, out TValue value) => _inner.TryGetValue(key, out value);
+
+    public void Clear() => _inner.Clear();
+
+    public IReadOnlyDictionary<TKey, TValue> AsReadOnly() => _inner;
+
+    public Dictionary<TKey, TValue>.Enumerator GetEnumerator() => _inner.GetEnumerator();
+
+    IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() => _inner.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => _inner.GetEnumerator();
+}


### PR DESCRIPTION
## Summary
- introduce configuration bindings for toggling the wanted system and exposing heat/ambush settings
- add player heat data structures, persistence helpers, and a lazy dictionary utility for wanted tracking
- register a wanted module within the module host that initialises the system and schedules autosaves

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f21726ed688327bbf0e1140d2c0522