### PR TITLE
Replace MathF.Clamp usage in infamy system

### DIFF
--- a/VeinWares.SubtleByte/Config/FactionInfamyConfig.cs
+++ b/VeinWares.SubtleByte/Config/FactionInfamyConfig.cs
@@ -1,0 +1,169 @@
+using System;
+using BepInEx.Configuration;
+
+namespace VeinWares.SubtleByte.Config;
+
+internal static class FactionInfamyConfig
+{
+    private static bool _initialized;
+    private static ConfigEntry<float> _hateGainMultiplier;
+    private static ConfigEntry<float> _hateDecayPerMinute;
+    private static ConfigEntry<float> _cooldownGraceSeconds;
+    private static ConfigEntry<float> _combatCooldownSeconds;
+    private static ConfigEntry<float> _ambushCooldownMinutes;
+    private static ConfigEntry<float> _minimumAmbushHate;
+    private static ConfigEntry<int> _maximumHate;
+    private static ConfigEntry<int> _autosaveMinutes;
+    private static ConfigEntry<int> _autosaveBackups;
+
+    public static void Initialize(ConfigFile configFile)
+    {
+        if (_initialized)
+        {
+            return;
+        }
+
+        if (configFile is null)
+        {
+            throw new ArgumentNullException(nameof(configFile));
+        }
+
+        _hateGainMultiplier = configFile.Bind(
+            "Faction Infamy",
+            "Hate Gain Multiplier",
+            1.0f,
+            "Scales the amount of hate granted per qualifying kill. Values below zero will be clamped to zero.");
+
+        _hateDecayPerMinute = configFile.Bind(
+            "Faction Infamy",
+            "Hate Decay Per Minute",
+            10.0f,
+            "Amount of hate removed from every active faction bucket each minute while the player is eligible for cooldown.");
+
+        _cooldownGraceSeconds = configFile.Bind(
+            "Faction Infamy",
+            "Cooldown Grace Seconds",
+            30.0f,
+            "How long after combat the player must remain idle before their hate begins to fade.");
+
+        _combatCooldownSeconds = configFile.Bind(
+            "Faction Infamy",
+            "Combat Cooldown Seconds",
+            15.0f,
+            "Minimum time between combat triggers that will reset the hate decay timer.");
+
+        _ambushCooldownMinutes = configFile.Bind(
+            "Faction Infamy",
+            "Ambush Cooldown Minutes",
+            15.0f,
+            "Minimum number of minutes that must pass before the same player can be ambushed again.");
+
+        _minimumAmbushHate = configFile.Bind(
+            "Faction Infamy",
+            "Minimum Ambush Hate",
+            50.0f,
+            "Players must reach this hate level (after multipliers) before ambush squads are considered.");
+
+        _maximumHate = configFile.Bind(
+            "Faction Infamy",
+            "Maximum Hate",
+            300,
+            "Upper bound for hate per faction. Any calculated hate beyond this value will be clamped.");
+
+        _autosaveMinutes = configFile.Bind(
+            "Faction Infamy",
+            "Autosave Minutes",
+            5,
+            "Interval, in minutes, for persisting infamy hate data to disk. Minimum of one minute.");
+
+        _autosaveBackups = configFile.Bind(
+            "Faction Infamy",
+            "Autosave Backups",
+            3,
+            "Number of rolling backup files to keep whenever the Faction Infamy system saves the hate database.");
+
+        ClampValues();
+
+        _initialized = true;
+    }
+
+    public static FactionInfamyConfigSnapshot CreateSnapshot()
+    {
+        if (!_initialized)
+        {
+            throw new InvalidOperationException("FactionInfamyConfig.Initialize must be called before creating a snapshot.");
+        }
+
+        ClampValues();
+
+        return new FactionInfamyConfigSnapshot(
+            MathF.Max(0f, _hateGainMultiplier.Value),
+            MathF.Max(0f, _hateDecayPerMinute.Value) / 60f,
+            TimeSpan.FromSeconds(MathF.Max(0f, _cooldownGraceSeconds.Value)),
+            TimeSpan.FromSeconds(MathF.Max(1f, _combatCooldownSeconds.Value)),
+            TimeSpan.FromMinutes(MathF.Max(1f, _ambushCooldownMinutes.Value)),
+            MathF.Max(0f, _minimumAmbushHate.Value),
+            Math.Max(1, _maximumHate.Value),
+            TimeSpan.FromMinutes(Math.Max(1, _autosaveMinutes.Value)),
+            Math.Clamp(_autosaveBackups.Value, 0, 20));
+    }
+
+    private static void ClampValues()
+    {
+        if (_hateGainMultiplier.Value < 0f)
+        {
+            _hateGainMultiplier.Value = 0f;
+        }
+
+        if (_hateDecayPerMinute.Value < 0f)
+        {
+            _hateDecayPerMinute.Value = 0f;
+        }
+
+        if (_cooldownGraceSeconds.Value < 0f)
+        {
+            _cooldownGraceSeconds.Value = 0f;
+        }
+
+        if (_combatCooldownSeconds.Value < 1f)
+        {
+            _combatCooldownSeconds.Value = 1f;
+        }
+
+        if (_ambushCooldownMinutes.Value < 1f)
+        {
+            _ambushCooldownMinutes.Value = 1f;
+        }
+
+        if (_minimumAmbushHate.Value < 0f)
+        {
+            _minimumAmbushHate.Value = 0f;
+        }
+
+        if (_maximumHate.Value < 1)
+        {
+            _maximumHate.Value = 1;
+        }
+
+        if (_autosaveMinutes.Value < 1)
+        {
+            _autosaveMinutes.Value = 1;
+        }
+
+        if (_autosaveBackups.Value < 0)
+        {
+            _autosaveBackups.Value = 0;
+        }
+    }
+}
+
+internal readonly record struct FactionInfamyConfigSnapshot(
+    float HateGainMultiplier,
+    float HateDecayPerSecond,
+    TimeSpan CooldownGrace,
+    TimeSpan CombatCooldown,
+    TimeSpan AmbushCooldown,
+    float MinimumAmbushHate,
+    int MaximumHate,
+    TimeSpan AutosaveInterval,
+    int AutosaveBackupCount);

--- a/VeinWares.SubtleByte/Config/SubtleBytePluginConfig.cs
+++ b/VeinWares.SubtleByte/Config/SubtleBytePluginConfig.cs
@@ -12,12 +12,14 @@ namespace VeinWares.SubtleByte.Config
         private static ConfigEntry<bool> _relicDebugEventsEnabled;
         private static ConfigEntry<bool> _itemStackServiceEnabled;
         private static ConfigEntry<bool> _debugLogsEnabled;
+        private static ConfigEntry<bool> _infamySystemEnabled;
 
         public static bool EmptyBottleRefundEnabled => _emptyBottleRefundEnabled?.Value ?? true;
         internal static ConfigEntry<bool> EmptyBottleRefundEnabledEntry => _emptyBottleRefundEnabled;
         public static bool RelicDebugEventsEnabled => _relicDebugEventsEnabled?.Value ?? true;
         public static bool ItemStackServiceEnabled => _itemStackServiceEnabled?.Value ?? true;
         public static bool DebugLogsEnabled => _debugLogsEnabled?.Value ?? false;
+        public static bool InfamySystemEnabled => _infamySystemEnabled?.Value ?? false;
 
         public static void Initialize()
         {
@@ -50,6 +52,14 @@ namespace VeinWares.SubtleByte.Config
                 "Enable Debug Logs",
                 false,
                 "When true, SubtleByte emits all diagnostic log messages. Set to false to silence the mod's logging entirely.");
+
+            _infamySystemEnabled = _configFile.Bind(
+                "Faction Infamy",
+                "Enable Faction Infamy System",
+                false,
+                "Master toggle for the Faction Infamy gameplay system. When disabled, the infamy modules, commands, and persistence are not initialised.");
+
+            FactionInfamyConfig.Initialize(_configFile);
         }
 
         public static void SetDebugLogs(bool enabled)
@@ -61,5 +71,7 @@ namespace VeinWares.SubtleByte.Config
             _debugLogsEnabled.Value = enabled;
             _configFile?.Save();
         }
+
+        internal static ConfigEntry<bool> InfamySystemEnabledEntry => _infamySystemEnabled;
     }
 }

--- a/VeinWares.SubtleByte/Infrastructure/ModuleConfig.cs
+++ b/VeinWares.SubtleByte/Infrastructure/ModuleConfig.cs
@@ -5,10 +5,15 @@ namespace VeinWares.SubtleByte.Infrastructure;
 
 public sealed class ModuleConfig
 {
-    public ModuleConfig(ConfigEntry<bool> bottleRefundEnabled)
+    public ModuleConfig(
+        ConfigEntry<bool> bottleRefundEnabled,
+        ConfigEntry<bool> infamySystemEnabled)
     {
         BottleRefundEnabled = bottleRefundEnabled ?? throw new ArgumentNullException(nameof(bottleRefundEnabled));
+        InfamySystemEnabled = infamySystemEnabled ?? throw new ArgumentNullException(nameof(infamySystemEnabled));
     }
 
     public ConfigEntry<bool> BottleRefundEnabled { get; }
+
+    public ConfigEntry<bool> InfamySystemEnabled { get; }
 }

--- a/VeinWares.SubtleByte/Models/FactionInfamy/PlayerHateData.cs
+++ b/VeinWares.SubtleByte/Models/FactionInfamy/PlayerHateData.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using VeinWares.SubtleByte.Utilities;
+
+namespace VeinWares.SubtleByte.Models.FactionInfamy;
+
+internal sealed class PlayerHateData
+{
+    private readonly LazyDictionary<string, HateEntry> _factionHate = new(() => new HateEntry());
+
+    public DateTime LastCombatStart { get; set; }
+
+    public DateTime LastCombatEnd { get; set; }
+
+    public IReadOnlyDictionary<string, HateEntry> FactionHate => _factionHate.AsReadOnly();
+
+    public HateEntry GetHate(string factionId) => _factionHate[factionId];
+
+    public void SetHate(string factionId, HateEntry entry)
+    {
+        _factionHate[factionId] = entry;
+    }
+
+    public bool ClearFaction(string factionId)
+    {
+        return _factionHate.Remove(factionId);
+    }
+
+    public Dictionary<string, HateEntry> ExportSnapshot()
+    {
+        var result = new Dictionary<string, HateEntry>(_factionHate.Count);
+        foreach (var pair in _factionHate)
+        {
+            result[pair.Key] = pair.Value;
+        }
+
+        return result;
+    }
+
+    public bool RunCooldown(float decayPerSecond, float deltaSeconds, float removalThreshold)
+    {
+        if (_factionHate.Count == 0 || decayPerSecond <= 0f || deltaSeconds <= 0f)
+        {
+            return false;
+        }
+
+        var toRemove = new List<string>();
+        var changed = false;
+        var decayAmount = decayPerSecond * deltaSeconds;
+
+        foreach (var pair in _factionHate)
+        {
+            var entry = pair.Value;
+            if (entry.Hate <= 0f)
+            {
+                if (entry.Hate <= removalThreshold)
+                {
+                    toRemove.Add(pair.Key);
+                }
+
+                continue;
+            }
+
+            var newHate = MathF.Max(0f, entry.Hate - decayAmount);
+            if (MathF.Abs(newHate - entry.Hate) > 0.001f)
+            {
+                changed = true;
+            }
+
+            entry.Hate = newHate;
+            entry.LastUpdated = DateTime.UtcNow;
+            _factionHate[pair.Key] = entry;
+
+            if (newHate <= removalThreshold)
+            {
+                toRemove.Add(pair.Key);
+            }
+        }
+
+        foreach (var faction in toRemove)
+        {
+            _factionHate.Remove(faction);
+            changed = true;
+        }
+
+        return changed;
+    }
+}
+
+internal struct HateEntry
+{
+    public float Hate { get; set; }
+
+    public DateTime LastUpdated { get; set; }
+
+    public DateTime LastAmbush { get; set; }
+}

--- a/VeinWares.SubtleByte/Modules/FactionInfamy/FactionInfamyModule.cs
+++ b/VeinWares.SubtleByte/Modules/FactionInfamy/FactionInfamyModule.cs
@@ -1,0 +1,78 @@
+using System;
+using VeinWares.SubtleByte.Config;
+using VeinWares.SubtleByte.Infrastructure;
+using VeinWares.SubtleByte.Services.FactionInfamy;
+
+namespace VeinWares.SubtleByte.Modules.FactionInfamy;
+
+internal sealed class FactionInfamyModule : IModule, IUpdateModule
+{
+    private bool _enabled;
+    private bool _disposed;
+    private Runtime.Scheduling.IntervalScheduler.ScheduledHandle _autosaveHandle;
+    private bool _autosaveRegistered;
+
+    public void Initialize(ModuleContext context)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        _enabled = context.Config.InfamySystemEnabled.Value && SubtleBytePluginConfig.InfamySystemEnabled;
+        if (!_enabled)
+        {
+            context.Log.LogInfo("[Infamy] Faction Infamy system disabled via configuration.");
+            return;
+        }
+
+        FactionInfamyRuntime.Initialize(context.Log);
+
+        var snapshot = FactionInfamyConfig.CreateSnapshot();
+        FactionInfamySystem.Initialize(snapshot, context.Log);
+
+        _autosaveHandle = context.Scheduler.Schedule(
+            snapshot.AutosaveInterval,
+            FactionInfamySystem.FlushPersistence,
+            runImmediately: false);
+        _autosaveRegistered = true;
+
+        context.Log.LogInfo("[Infamy] Faction Infamy module initialised.");
+    }
+
+    public void OnUpdate(float deltaTime)
+    {
+        if (!_enabled || _disposed)
+        {
+            return;
+        }
+
+        FactionInfamyRuntime.ProcessQueues();
+
+        FactionInfamySystem.Tick(deltaTime);
+
+        FactionInfamyRuntime.ProcessQueues();
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        if (_autosaveRegistered)
+        {
+            _autosaveHandle.Dispose();
+        }
+
+        if (_enabled)
+        {
+            FactionInfamySystem.FlushPersistence();
+            FactionInfamySystem.Shutdown();
+            FactionInfamyRuntime.Shutdown();
+        }
+
+        _disposed = true;
+    }
+}

--- a/VeinWares.SubtleByte/Plugin.cs
+++ b/VeinWares.SubtleByte/Plugin.cs
@@ -15,6 +15,7 @@ using VeinWares.SubtleByte.Modules.Crafting;
 using VeinWares.SubtleByte.Runtime.Unity;
 using VeinWares.SubtleByte.Services;
 using VeinWares.SubtleByte.Utilities;
+using VeinWares.SubtleByte.Modules.FactionInfamy;
 
 namespace VeinWares.SubtleByte
 {
@@ -46,11 +47,14 @@ namespace VeinWares.SubtleByte
 
             var performanceLogPath = Path.Combine(Paths.ConfigPath, "VeinWares SubtleByte", "performance.log");
             var performanceTracker = new PerformanceTracker(Log, thresholdMilliseconds: 5.0, performanceLogPath);
-            var moduleConfig = new ModuleConfig(SubtleBytePluginConfig.EmptyBottleRefundEnabledEntry);
+            var moduleConfig = new ModuleConfig(
+                SubtleBytePluginConfig.EmptyBottleRefundEnabledEntry,
+                SubtleBytePluginConfig.InfamySystemEnabledEntry);
             _moduleHost = ModuleHost.Create(Log, performanceTracker, new Func<IModule>[]
             {
                 () => new HeartbeatModule(),
                 () => new BottleRefundModule(),
+                () => new FactionInfamyModule(),
             }, moduleConfig);
 
             _moduleHost.Initialize();

--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyPersistence.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyPersistence.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using BepInEx;
+using VeinWares.SubtleByte.Models.FactionInfamy;
+using VeinWares.SubtleByte.Utilities;
+
+namespace VeinWares.SubtleByte.Services.FactionInfamy;
+
+internal static class FactionInfamyPersistence
+{
+    private static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true
+    };
+
+    private static string ConfigDirectory => Path.Combine(Paths.ConfigPath, "VeinWares SubtleByte");
+    private static string SavePath => Path.Combine(ConfigDirectory, "playerInfamyLevel.json");
+
+    public static Dictionary<ulong, PlayerHateData> Load()
+    {
+        try
+        {
+            if (!File.Exists(SavePath))
+            {
+                return new Dictionary<ulong, PlayerHateData>();
+            }
+
+            var json = File.ReadAllText(SavePath);
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return new Dictionary<ulong, PlayerHateData>();
+            }
+
+            var payload = JsonSerializer.Deserialize<Dictionary<string, PlayerHateRecord>>(json, Options);
+            if (payload is null)
+            {
+                return new Dictionary<ulong, PlayerHateData>();
+            }
+
+            return payload
+                .Select(static pair => new KeyValuePair<ulong, PlayerHateData>(
+                    ulong.TryParse(pair.Key, out var steamId) ? steamId : 0,
+                    FromRecord(pair.Value)))
+                .Where(static pair => pair.Key != 0)
+                .ToDictionary(static pair => pair.Key, static pair => pair.Value);
+        }
+        catch (Exception ex)
+        {
+            ModLogger.Error($"[InfamyPersistence] Failed to load hate data: {ex.Message}");
+            return new Dictionary<ulong, PlayerHateData>();
+        }
+    }
+
+    public static void Save(Dictionary<string, PlayerHateRecord> snapshot, int backupCount)
+    {
+        if (snapshot is null)
+        {
+            throw new ArgumentNullException(nameof(snapshot));
+        }
+
+        try
+        {
+            Directory.CreateDirectory(ConfigDirectory);
+
+            if (File.Exists(SavePath) && backupCount > 0)
+            {
+                CreateRollingBackups(backupCount);
+            }
+
+            var json = JsonSerializer.Serialize(snapshot, Options);
+            File.WriteAllText(SavePath, json);
+        }
+        catch (Exception ex)
+        {
+            ModLogger.Error($"[InfamyPersistence] Failed to save hate data: {ex.Message}");
+        }
+    }
+
+    private static PlayerHateData FromRecord(PlayerHateRecord record)
+    {
+        var data = new PlayerHateData
+        {
+            LastCombatStart = record.LastCombatStart,
+            LastCombatEnd = record.LastCombatEnd
+        };
+
+        if (record.Factions is null)
+        {
+            return data;
+        }
+
+        foreach (var faction in record.Factions)
+        {
+            var entry = new HateEntry
+            {
+                Hate = faction.Value.Hate,
+                LastAmbush = faction.Value.LastAmbush,
+                LastUpdated = faction.Value.LastUpdated
+            };
+            data.SetHate(faction.Key, entry);
+        }
+
+        return data;
+    }
+
+    private static void CreateRollingBackups(int backupCount)
+    {
+        try
+        {
+            for (var index = backupCount - 1; index >= 0; index--)
+            {
+                var source = index == 0 ? SavePath : GetBackupPath(index - 1);
+                var destination = GetBackupPath(index);
+
+                if (File.Exists(source))
+                {
+                    File.Copy(source, destination, overwrite: true);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            ModLogger.Warn($"[InfamyPersistence] Failed to rotate backups: {ex.Message}");
+        }
+    }
+
+    private static string GetBackupPath(int index)
+    {
+        var suffix = index.ToString().PadLeft(2, '0');
+        var fileName = $"playerInfamyLevel.json.bak{suffix}";
+        return Path.Combine(ConfigDirectory, fileName);
+    }
+}
+
+internal sealed class PlayerHateRecord
+{
+    public Dictionary<string, HateEntryRecord> Factions { get; set; } = new();
+
+    public DateTime LastCombatStart { get; set; }
+
+    public DateTime LastCombatEnd { get; set; }
+}
+
+internal sealed class HateEntryRecord
+{
+    public float Hate { get; set; }
+
+    public DateTime LastUpdated { get; set; }
+
+    public DateTime LastAmbush { get; set; }
+}

--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyRuntime.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyRuntime.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Concurrent;
+using BepInEx.Logging;
+
+namespace VeinWares.SubtleByte.Services.FactionInfamy;
+
+internal static class FactionInfamyRuntime
+{
+    private static readonly ConcurrentQueue<Action> MainThreadActions = new();
+    private static ManualLogSource? _log;
+    private static bool _initialized;
+
+    public static event Action<FactionInfamyPlayerSnapshot>? PlayerHateChanged;
+    public static event Action<ulong>? PlayerHateCleared;
+
+    public static void Initialize(ManualLogSource log)
+    {
+        if (log is null)
+        {
+            throw new ArgumentNullException(nameof(log));
+        }
+
+        _log = log;
+        _initialized = true;
+    }
+
+    public static void Shutdown()
+    {
+        _initialized = false;
+        _log = null;
+
+        while (MainThreadActions.TryDequeue(out _))
+        {
+        }
+
+        PlayerHateChanged = null;
+        PlayerHateCleared = null;
+    }
+
+    public static void ProcessQueues()
+    {
+        if (!_initialized)
+        {
+            return;
+        }
+
+        while (MainThreadActions.TryDequeue(out var action))
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception ex)
+            {
+                _log?.LogError($"[Infamy] Exception while running queued action: {ex}");
+            }
+        }
+    }
+
+    public static void NotifyPlayerHateChanged(FactionInfamyPlayerSnapshot snapshot)
+    {
+        if (!_initialized)
+        {
+            return;
+        }
+
+        Enqueue(() =>
+        {
+            try
+            {
+                PlayerHateChanged?.Invoke(snapshot);
+            }
+            catch (Exception ex)
+            {
+                _log?.LogError($"[Infamy] Listener threw while handling hate update for {snapshot.SteamId}: {ex}");
+            }
+        });
+    }
+
+    public static void NotifyPlayerHateCleared(ulong steamId)
+    {
+        if (!_initialized)
+        {
+            return;
+        }
+
+        Enqueue(() =>
+        {
+            try
+            {
+                PlayerHateCleared?.Invoke(steamId);
+            }
+            catch (Exception ex)
+            {
+                _log?.LogError($"[Infamy] Listener threw while handling hate clear for {steamId}: {ex}");
+            }
+        });
+    }
+
+    private static void Enqueue(Action action)
+    {
+        if (action is null)
+        {
+            return;
+        }
+
+        MainThreadActions.Enqueue(action);
+    }
+}

--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamySystem.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamySystem.cs
@@ -1,0 +1,291 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using BepInEx.Logging;
+using VeinWares.SubtleByte.Config;
+using VeinWares.SubtleByte.Models.FactionInfamy;
+
+namespace VeinWares.SubtleByte.Services.FactionInfamy;
+
+internal static class FactionInfamySystem
+{
+    private static readonly ConcurrentDictionary<ulong, PlayerHateData> PlayerHate = new();
+    private static ManualLogSource? _log;
+    private static FactionInfamyConfigSnapshot _config;
+    private static bool _initialized;
+    private static bool _dirty;
+
+    public static bool Enabled => _initialized;
+
+    public static int AutosaveBackupCount { get; private set; }
+
+    public static void Initialize(FactionInfamyConfigSnapshot config, ManualLogSource log)
+    {
+        if (log is null)
+        {
+            throw new ArgumentNullException(nameof(log));
+        }
+
+        _log = log;
+        _config = config;
+        AutosaveBackupCount = config.AutosaveBackupCount;
+
+        PlayerHate.Clear();
+        var loaded = FactionInfamyPersistence.Load();
+        foreach (var pair in loaded)
+        {
+            PlayerHate[pair.Key] = pair.Value;
+            FactionInfamyRuntime.NotifyPlayerHateChanged(CreateSnapshot(pair.Key, pair.Value));
+        }
+
+        _dirty = false;
+        _initialized = true;
+        _log.LogInfo("[Infamy] Faction Infamy system initialised.");
+    }
+
+    public static void Shutdown()
+    {
+        if (!_initialized)
+        {
+            return;
+        }
+
+        FlushPersistence();
+        PlayerHate.Clear();
+        _initialized = false;
+        _log?.LogInfo("[Infamy] Faction Infamy system shut down.");
+    }
+
+    public static void Tick(float deltaTime)
+    {
+        if (!_initialized || deltaTime <= 0f)
+        {
+            return;
+        }
+
+        if (_config.HateDecayPerSecond <= 0f)
+        {
+            return;
+        }
+
+        var now = DateTime.UtcNow;
+        var removalThreshold = 0.01f;
+
+        var playersToClear = new List<ulong>();
+
+        foreach (var pair in PlayerHate)
+        {
+            var data = pair.Value;
+            if (!IsEligibleForCooldown(data, now))
+            {
+                continue;
+            }
+
+            if (data.RunCooldown(_config.HateDecayPerSecond, deltaTime, removalThreshold))
+            {
+                _dirty = true;
+                if (data.FactionHate.Count == 0)
+                {
+                    playersToClear.Add(pair.Key);
+                }
+                else
+                {
+                    FactionInfamyRuntime.NotifyPlayerHateChanged(CreateSnapshot(pair.Key, data));
+                }
+            }
+        }
+
+        for (var i = 0; i < playersToClear.Count; i++)
+        {
+            var steamId = playersToClear[i];
+            if (PlayerHate.TryRemove(steamId, out _))
+            {
+                FactionInfamyRuntime.NotifyPlayerHateCleared(steamId);
+            }
+        }
+    }
+
+    public static void RegisterHateGain(ulong steamId, string factionId, float baseHate)
+    {
+        if (!_initialized || steamId == 0UL || string.IsNullOrWhiteSpace(factionId) || baseHate <= 0f)
+        {
+            return;
+        }
+
+        var adjusted = baseHate * _config.HateGainMultiplier;
+        var data = PlayerHate.GetOrAdd(steamId, static _ => new PlayerHateData());
+        var entry = data.GetHate(factionId);
+        var newHate = Math.Clamp(entry.Hate + adjusted, 0f, _config.MaximumHate);
+        entry.Hate = newHate;
+        entry.LastUpdated = DateTime.UtcNow;
+        data.SetHate(factionId, entry);
+        _dirty = true;
+        FactionInfamyRuntime.NotifyPlayerHateChanged(CreateSnapshot(steamId, data));
+    }
+
+    public static void RegisterHateGain(IEnumerable<ulong> steamIds, string factionId, float baseHate)
+    {
+        if (steamIds is null)
+        {
+            throw new ArgumentNullException(nameof(steamIds));
+        }
+
+        foreach (var steamId in steamIds)
+        {
+            RegisterHateGain(steamId, factionId, baseHate);
+        }
+    }
+
+    public static void RegisterDeath(ulong steamId)
+    {
+        if (!_initialized)
+        {
+            return;
+        }
+
+        if (PlayerHate.TryRemove(steamId, out _))
+        {
+            _dirty = true;
+            FactionInfamyRuntime.NotifyPlayerHateCleared(steamId);
+        }
+    }
+
+    public static void RegisterCombatStart(ulong steamId)
+    {
+        if (!_initialized)
+        {
+            return;
+        }
+
+        var data = PlayerHate.GetOrAdd(steamId, static _ => new PlayerHateData());
+        data.LastCombatStart = DateTime.UtcNow;
+        FactionInfamyRuntime.NotifyPlayerHateChanged(CreateSnapshot(steamId, data));
+    }
+
+    public static void RegisterCombatEnd(ulong steamId)
+    {
+        if (!_initialized)
+        {
+            return;
+        }
+
+        if (!PlayerHate.TryGetValue(steamId, out var data))
+        {
+            return;
+        }
+
+        data.LastCombatEnd = DateTime.UtcNow;
+        FactionInfamyRuntime.NotifyPlayerHateChanged(CreateSnapshot(steamId, data));
+    }
+
+    public static void RegisterAmbush(ulong steamId, string factionId)
+    {
+        if (!_initialized || string.IsNullOrWhiteSpace(factionId))
+        {
+            return;
+        }
+
+        var data = PlayerHate.GetOrAdd(steamId, static _ => new PlayerHateData());
+        var entry = data.GetHate(factionId);
+        entry.LastAmbush = DateTime.UtcNow;
+        data.SetHate(factionId, entry);
+        _dirty = true;
+        FactionInfamyRuntime.NotifyPlayerHateChanged(CreateSnapshot(steamId, data));
+    }
+
+    public static bool TryGetPlayerHate(ulong steamId, out FactionInfamyPlayerSnapshot snapshot)
+    {
+        if (!_initialized)
+        {
+            snapshot = new FactionInfamyPlayerSnapshot(steamId, new Dictionary<string, HateEntry>(), DateTime.MinValue, DateTime.MinValue);
+            return false;
+        }
+
+        if (PlayerHate.TryGetValue(steamId, out var data))
+        {
+            snapshot = CreateSnapshot(steamId, data);
+            return true;
+        }
+
+        snapshot = new FactionInfamyPlayerSnapshot(steamId, new Dictionary<string, HateEntry>(), DateTime.MinValue, DateTime.MinValue);
+        return false;
+    }
+
+    public static void ClearPlayerHate(ulong steamId)
+    {
+        if (!_initialized)
+        {
+            return;
+        }
+
+        if (PlayerHate.TryRemove(steamId, out _))
+        {
+            _dirty = true;
+            FactionInfamyRuntime.NotifyPlayerHateCleared(steamId);
+        }
+    }
+
+    public static void FlushPersistence()
+    {
+        if (!_initialized || !_dirty)
+        {
+            return;
+        }
+
+        try
+        {
+            var snapshot = CreateSerializableSnapshot();
+            FactionInfamyPersistence.Save(snapshot, AutosaveBackupCount);
+            _dirty = false;
+        }
+        catch (Exception ex)
+        {
+            _log?.LogError($"[Infamy] Failed to flush infamy persistence: {ex.Message}");
+        }
+    }
+
+    private static bool IsEligibleForCooldown(PlayerHateData data, DateTime now)
+    {
+        if (data.LastCombatEnd == DateTime.MinValue)
+        {
+            return true;
+        }
+
+        var elapsed = now - data.LastCombatEnd;
+        return elapsed >= _config.CooldownGrace;
+    }
+
+    private static Dictionary<string, PlayerHateRecord> CreateSerializableSnapshot()
+    {
+        return PlayerHate
+            .Where(static pair => pair.Value.FactionHate.Count > 0)
+            .ToDictionary(
+                static pair => pair.Key.ToString(),
+                static pair => new PlayerHateRecord
+                {
+                    LastCombatStart = pair.Value.LastCombatStart,
+                    LastCombatEnd = pair.Value.LastCombatEnd,
+                    Factions = pair.Value.ExportSnapshot()
+                        .ToDictionary(
+                            static faction => faction.Key,
+                            static faction => new HateEntryRecord
+                            {
+                                Hate = faction.Value.Hate,
+                                LastAmbush = faction.Value.LastAmbush,
+                                LastUpdated = faction.Value.LastUpdated
+                            })
+                });
+    }
+
+    private static FactionInfamyPlayerSnapshot CreateSnapshot(ulong steamId, PlayerHateData data)
+    {
+        return new FactionInfamyPlayerSnapshot(steamId, data.ExportSnapshot(), data.LastCombatStart, data.LastCombatEnd);
+    }
+}
+
+internal readonly record struct FactionInfamyPlayerSnapshot(
+    ulong SteamId,
+    IReadOnlyDictionary<string, HateEntry> HateByFaction,
+    DateTime LastCombatStart,
+    DateTime LastCombatEnd);

--- a/VeinWares.SubtleByte/Utilities/LazyDictionary.cs
+++ b/VeinWares.SubtleByte/Utilities/LazyDictionary.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace VeinWares.SubtleByte.Utilities;
+
+internal sealed class LazyDictionary<TKey, TValue> : IEnumerable<KeyValuePair<TKey, TValue>> where TKey : notnull
+{
+    private readonly Func<TValue> _factory;
+    private readonly Dictionary<TKey, TValue> _inner;
+
+    public LazyDictionary(Func<TValue> factory)
+    {
+        _factory = factory ?? throw new ArgumentNullException(nameof(factory));
+        _inner = new Dictionary<TKey, TValue>();
+    }
+
+    public TValue this[TKey key]
+    {
+        get
+        {
+            if (!_inner.TryGetValue(key, out var value))
+            {
+                value = _factory();
+                _inner[key] = value;
+            }
+
+            return value;
+        }
+        set => _inner[key] = value;
+    }
+
+    public int Count => _inner.Count;
+
+    public bool Remove(TKey key) => _inner.Remove(key);
+
+    public bool TryGetValue(TKey key, out TValue value) => _inner.TryGetValue(key, out value);
+
+    public void Clear() => _inner.Clear();
+
+    public IReadOnlyDictionary<TKey, TValue> AsReadOnly() => _inner;
+
+    public Dictionary<TKey, TValue>.Enumerator GetEnumerator() => _inner.GetEnumerator();
+
+    IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() => _inner.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => _inner.GetEnumerator();
+}


### PR DESCRIPTION
## Summary
- replace the MathF.Clamp call in the faction infamy system with Math.Clamp so the build targets the supported API

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f21726ed688327bbf0e1140d2c0522