### PR TITLE
Hook faction infamy into death events

### DIFF
--- a/VeinWares.SubtleByte/Patches/DeathEventListenerSystemInfamyPatch.cs
+++ b/VeinWares.SubtleByte/Patches/DeathEventListenerSystemInfamyPatch.cs
@@ -1,0 +1,112 @@
+using HarmonyLib;
+using ProjectM;
+using Unity.Collections;
+using Unity.Entities;
+using VeinWares.SubtleByte.Extensions;
+using VeinWares.SubtleByte.Services.FactionInfamy;
+
+namespace VeinWares.SubtleByte.Patches;
+
+[HarmonyPatch(typeof(DeathEventListenerSystem), nameof(DeathEventListenerSystem.OnUpdate))]
+internal static class DeathEventListenerSystemInfamyPatch
+{
+    private static void Postfix(DeathEventListenerSystem __instance)
+    {
+        if (!FactionInfamySystem.Enabled)
+        {
+            return;
+        }
+
+        var deathEvents = __instance._DeathEventQuery.ToComponentDataArray<DeathEvent>(Allocator.Temp);
+        try
+        {
+            foreach (var deathEvent in deathEvents)
+            {
+                HandlePlayerDeath(deathEvent.Died);
+                HandleKill(__instance.EntityManager, deathEvent);
+            }
+        }
+        finally
+        {
+            deathEvents.Dispose();
+        }
+    }
+
+    private static void HandleKill(EntityManager entityManager, DeathEvent deathEvent)
+    {
+        var victim = deathEvent.Died;
+        if (!QualifiesAsInfamyKill(entityManager, victim))
+        {
+            return;
+        }
+
+        var killer = ResolveKiller(entityManager, deathEvent.Killer);
+        if (killer == Entity.Null || killer == victim)
+        {
+            return;
+        }
+
+        if (!killer.Has<PlayerCharacter>() || !killer.TryGetSteamId(out var steamId) || steamId == 0UL)
+        {
+            return;
+        }
+
+        if (!FactionInfamyVictimResolver.TryGetHateForVictim(victim, out var factionId, out var baseHate))
+        {
+            return;
+        }
+
+        FactionInfamySystem.RegisterCombatStart(steamId);
+        FactionInfamySystem.RegisterHateGain(steamId, factionId, baseHate);
+    }
+
+    private static void HandlePlayerDeath(Entity victim)
+    {
+        if (!victim.TryGetSteamId(out var steamId) || steamId == 0UL)
+        {
+            return;
+        }
+
+        FactionInfamySystem.RegisterDeath(steamId);
+    }
+
+    private static bool QualifiesAsInfamyKill(EntityManager entityManager, Entity victim)
+    {
+        if (victim == Entity.Null)
+        {
+            return false;
+        }
+
+        if (entityManager.HasComponent<Minion>(victim))
+        {
+            return false;
+        }
+
+        if (!entityManager.HasComponent<UnitLevel>(victim))
+        {
+            return false;
+        }
+
+        if (!entityManager.HasComponent<Movement>(victim))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static Entity ResolveKiller(EntityManager entityManager, Entity killer)
+    {
+        if (killer == Entity.Null)
+        {
+            return Entity.Null;
+        }
+
+        if (entityManager.HasComponent<Minion>(killer) && entityManager.TryGetComponentData<EntityOwner>(killer, out var owner))
+        {
+            return owner.Owner;
+        }
+
+        return killer;
+    }
+}

--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyVictimResolver.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyVictimResolver.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using Unity.Entities;
+using ProjectM;
+using VeinWares.SubtleByte.Extensions;
+
+namespace VeinWares.SubtleByte.Services.FactionInfamy;
+
+internal static class FactionInfamyVictimResolver
+{
+    private const float DefaultBaseHate = 10f;
+    private const float VBloodHateMultiplier = 10f;
+
+    private static readonly Dictionary<int, string> AggregatedFactionMap = new()
+    {
+        { PrefabsFactionIds.Bandits, "Bandits" },
+        { PrefabsFactionIds.TradersT01, "Bandits" },
+        { PrefabsFactionIds.Blackfangs, "Blackfangs" },
+        { PrefabsFactionIds.BlackfangsLivith, "Blackfangs" },
+        { PrefabsFactionIds.Militia, "Militia" },
+        { PrefabsFactionIds.ChurchOfLum, "Militia" },
+        { PrefabsFactionIds.ChurchOfLumSpotVampire, "Militia" },
+        { PrefabsFactionIds.TradersT02, "Militia" },
+        { PrefabsFactionIds.WorldPrisoners, "Militia" },
+        { PrefabsFactionIds.Gloomrot, "Gloomrot" },
+        { PrefabsFactionIds.Legion, "Legion" },
+        { PrefabsFactionIds.Bear, "Critters" },
+        { PrefabsFactionIds.Critters, "Critters" },
+        { PrefabsFactionIds.Wolves, "Critters" },
+        { PrefabsFactionIds.Undead, "Undead" },
+        { PrefabsFactionIds.Werewolf, "Werewolf" },
+        { PrefabsFactionIds.WerewolfHuman, "Werewolf" },
+    };
+
+    private static readonly Dictionary<int, float> BaseHateOverrides = new()
+    {
+        { PrefabsFactionIds.TradersT01, 300f },
+        { PrefabsFactionIds.TradersT02, 300f },
+        { PrefabsFactionIds.ChurchOfLumSpotVampire, 25f },
+        { PrefabsFactionIds.ChurchOfLum, 15f },
+        { PrefabsFactionIds.Undead, 5f },
+        { PrefabsFactionIds.Werewolf, 20f },
+        { PrefabsFactionIds.WerewolfHuman, 20f },
+    };
+
+    public static bool TryGetHateForVictim(Entity victim, out string factionId, out float baseHate)
+    {
+        factionId = string.Empty;
+        baseHate = 0f;
+
+        if (!victim.TryGetComponent<FactionReference>(out var factionReference))
+        {
+            return false;
+        }
+
+        var factionGuid = factionReference.FactionGuid._Value;
+        if (!AggregatedFactionMap.TryGetValue(factionGuid.GuidHash, out factionId))
+        {
+            return false;
+        }
+
+        baseHate = BaseHateOverrides.TryGetValue(factionGuid.GuidHash, out var overrideValue)
+            ? overrideValue
+            : DefaultBaseHate;
+
+        if (victim.Has<VBloodUnit>())
+        {
+            baseHate *= VBloodHateMultiplier;
+        }
+
+        return baseHate > 0f;
+    }
+
+    private static class PrefabsFactionIds
+    {
+        public const int Bandits = -413163549;
+        public const int TradersT01 = 30052367;
+        public const int Blackfangs = 932337192;
+        public const int BlackfangsLivith = -1460095921;
+        public const int Militia = 1057375699;
+        public const int ChurchOfLum = 1094603131;
+        public const int ChurchOfLumSpotVampire = 2395673;
+        public const int TradersT02 = 887347866;
+        public const int WorldPrisoners = 1977351396;
+        public const int Gloomrot = -1632475814;
+        public const int Legion = -772044125;
+        public const int Bear = 1344481611;
+        public const int Critters = 10678632;
+        public const int Wolves = -1671358863;
+        public const int Undead = 929074293;
+        public const int Werewolf = -2024618997;
+        public const int WerewolfHuman = 62959306;
+    }
+}


### PR DESCRIPTION
## Summary
- hook the server death listener so faction infamy updates on enemy kills and clears when a player dies
- add a victim resolver that maps faction prefabs to hate buckets and applies basic VBlood scaling

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68f265fbfcfc832797caf9f5d37de1c9