### PR TITLE
Fix BottleRefundModule inventory lookup

### DIFF
--- a/VeinWares.SubtleByte/Modules/Crafting/BottleRefundModule.cs
+++ b/VeinWares.SubtleByte/Modules/Crafting/BottleRefundModule.cs
@@ -116,7 +116,7 @@ public sealed class BottleRefundModule : IModule
                 _seenMixers.Add(mixer);
 
                 var shared = em.GetComponentData<BloodMixer_Shared>(mixer);
-                if (!TryGetOutputInventory(em, mixer, out var outputInv))
+                if (!TryGetOutputInventory(system.World, em, mixer, out var outputInv))
                 {
                     _snapshots[mixer] = new MixerSnapshot(shared.State, 0);
                     continue;
@@ -159,7 +159,7 @@ public sealed class BottleRefundModule : IModule
         }
     }
 
-    private bool TryGetOutputInventory(EntityManager em, Entity mixer, out Entity inventory)
+    private bool TryGetOutputInventory(World world, EntityManager em, Entity mixer, out Entity inventory)
     {
         if (_inventoryCache.TryGetValue(mixer, out var cacheEntry))
         {
@@ -255,7 +255,7 @@ public sealed class BottleRefundModule : IModule
             }
         }
 
-        if (TryResolveInventoryByQuery(system.World, em, mixer, out inventory))
+        if (TryResolveInventoryByQuery(world, em, mixer, out inventory))
         {
             _inventoryCache[mixer] = new InventoryCacheEntry(inventory, knownMissing: false, _updateIndex);
             return true;


### PR DESCRIPTION
## Summary
- pass the world from BloodMixerSystem_Update into TryGetOutputInventory
- ensure inventory queries reuse the cached entity query with the correct world reference

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f2aa6d93c88327b9c467bc0ab70081