### PR TITLE
Handle ambush scaling during spawn processing

### DIFF
--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamySpawnUtility.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamySpawnUtility.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using ProjectM;
 using Stunlock.Core;
 using Unity.Entities;
@@ -9,6 +10,9 @@ namespace VeinWares.SubtleByte.Services.FactionInfamy;
 internal static class FactionInfamySpawnUtility
 {
     private static readonly Entity PlaceholderEntity = new();
+    private static readonly ConcurrentDictionary<int, PendingSpawnCallback> PendingCallbacks = new();
+
+    public static bool HasPendingCallbacks => !PendingCallbacks.IsEmpty;
 
     public static float EncodeLifetime(int lifetimeSeconds, int level, SpawnFaction faction)
     {
@@ -56,8 +60,21 @@ internal static class FactionInfamySpawnUtility
         return checksumSection == level;
     }
 
-    public static void SpawnUnit(PrefabGUID prefab, float3 position, int count, float minRange, float maxRange, float lifetime)
+    public static void SpawnUnit(
+        PrefabGUID prefab,
+        float3 position,
+        int count,
+        float minRange,
+        float maxRange,
+        float lifetime,
+        Action<EntityManager, Entity>? preFinalize = null)
     {
+        if (preFinalize != null)
+        {
+            var key = BitConverter.SingleToInt32Bits(lifetime);
+            PendingCallbacks[key] = new PendingSpawnCallback(count, preFinalize);
+        }
+
         Core.Server.GetExistingSystemManaged<UnitSpawnerUpdateSystem>().SpawnUnit(
             PlaceholderEntity,
             prefab,
@@ -66,6 +83,57 @@ internal static class FactionInfamySpawnUtility
             minRange,
             maxRange,
             lifetime);
+    }
+
+    public static void TryExecuteSpawnCallback(EntityManager entityManager, Entity entity, float lifetime)
+    {
+        var key = BitConverter.SingleToInt32Bits(lifetime);
+        if (!PendingCallbacks.TryGetValue(key, out var callback))
+        {
+            return;
+        }
+
+        try
+        {
+            callback.Invoke(entityManager, entity);
+        }
+        catch
+        {
+            // Suppress any callback errors to avoid breaking spawn flow.
+        }
+
+        if (callback.Decrement() <= 0)
+        {
+            PendingCallbacks.TryRemove(key, out _);
+        }
+    }
+
+    public static void CancelSpawnCallback(float lifetime)
+    {
+        var key = BitConverter.SingleToInt32Bits(lifetime);
+        PendingCallbacks.TryRemove(key, out _);
+    }
+
+    private sealed class PendingSpawnCallback
+    {
+        private int _remaining;
+        private readonly Action<EntityManager, Entity> _callback;
+
+        public PendingSpawnCallback(int remaining, Action<EntityManager, Entity> callback)
+        {
+            _remaining = Math.Max(1, remaining);
+            _callback = callback;
+        }
+
+        public int Decrement()
+        {
+            return System.Threading.Interlocked.Decrement(ref _remaining);
+        }
+
+        public void Invoke(EntityManager entityManager, Entity entity)
+        {
+            _callback(entityManager, entity);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- run the ambush scaling pass during the UnitSpawner React prefix so entities are adjusted before spawn finalization
- expose pending spawn callback tracking so the spawn hook keeps watching while callbacks are queued

## Testing
- `dotnet build VeinWares.SubtleByte.sln` *(fails: dotnet is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68f2acf3f7208327bf87e5df3d35a555