### PR TITLE
Stabilize ambush spawn scaling callbacks

### DIFF
--- a/VeinWares.SubtleByte/Patches/UnitSpawnerReactSystemInfamyPatch.cs
+++ b/VeinWares.SubtleByte/Patches/UnitSpawnerReactSystemInfamyPatch.cs
@@ -22,9 +22,14 @@ internal static class UnitSpawnerReactSystemInfamyPatch
 
     private static bool _queryUnavailable;
 
-    private static void Postfix(UnitSpawnerReactSystem __instance)
+    private static void Prefix(UnitSpawnerReactSystem __instance)
     {
-        if (!FactionInfamySystem.Enabled || _queryUnavailable || !FactionInfamyAmbushService.HasPendingSpawns)
+        if (!FactionInfamySystem.Enabled || _queryUnavailable)
+        {
+            return;
+        }
+
+        if (!FactionInfamyAmbushService.HasPendingSpawns && !FactionInfamySpawnUtility.HasPendingCallbacks)
         {
             return;
         }
@@ -47,29 +52,37 @@ internal static class UnitSpawnerReactSystemInfamyPatch
                 return;
             }
 
-            var entityManager = __instance.EntityManager;
-            var entities = query.ToEntityArray(Allocator.Temp);
-            try
-            {
-                for (var i = 0; i < entities.Length; i++)
-                {
-                    var entity = entities[i];
-                    if (!entityManager.TryGetComponentData(entity, out LifeTime lifetime))
-                    {
-                        continue;
-                    }
-
-                    FactionInfamyAmbushService.TryHandleSpawnedEntity(entityManager, entity, lifetime.Duration);
-                }
-            }
-            finally
-            {
-                entities.Dispose();
-            }
+            ProcessPendingSpawns(__instance.EntityManager, query);
         }
         finally
         {
             query.Dispose();
+        }
+    }
+
+    private static void ProcessPendingSpawns(EntityManager entityManager, EntityQuery query)
+    {
+        var entities = query.ToEntityArray(Allocator.Temp);
+        try
+        {
+            for (var i = 0; i < entities.Length; i++)
+            {
+                var entity = entities[i];
+                if (!entityManager.TryGetComponentData(entity, out LifeTime lifetime))
+                {
+                    continue;
+                }
+
+                var handled = FactionInfamySpawnUtility.TryExecuteSpawnCallback(entityManager, entity, lifetime.Duration);
+                if (!handled)
+                {
+                    FactionInfamyAmbushService.TryHandleSpawnedEntity(entityManager, entity, lifetime.Duration);
+                }
+            }
+        }
+        finally
+        {
+            entities.Dispose();
         }
     }
 }

--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamySpawnUtility.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamySpawnUtility.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using ProjectM;
 using Stunlock.Core;
 using Unity.Entities;
@@ -9,55 +10,27 @@ namespace VeinWares.SubtleByte.Services.FactionInfamy;
 internal static class FactionInfamySpawnUtility
 {
     private static readonly Entity PlaceholderEntity = new();
+    private static readonly ConcurrentDictionary<int, PendingSpawnCallback> PendingCallbacks = new();
+    private static int _markerSequence = 100_000;
 
-    public static float EncodeLifetime(int lifetimeSeconds, int level, SpawnFaction faction)
+    public static bool HasPendingCallbacks => !PendingCallbacks.IsEmpty;
+
+    public static int SpawnUnit(
+        PrefabGUID prefab,
+        float3 position,
+        int count,
+        float minRange,
+        float maxRange,
+        float lifetime,
+        Action<EntityManager, Entity, int, float>? preFinalize = null)
     {
-        lifetimeSeconds = Math.Clamp(lifetimeSeconds / 10 * 10, 10, 990);
-        var factionDigit = Math.Clamp((int)faction, 0, 9);
-        level = Math.Clamp(level, 1, 99);
+        var marker = System.Threading.Interlocked.Increment(ref _markerSequence);
 
-        var factionComponent = factionDigit;
-        var levelComponent = level / 100f;
-        var checksumComponent = level / 10000f;
-
-        return lifetimeSeconds + factionComponent + levelComponent + checksumComponent;
-    }
-
-    public static bool TryDecodeLifetime(float encodedLifetime, out int level, out SpawnFaction faction)
-    {
-        var factionDigit = (int)(encodedLifetime % 10);
-        faction = Enum.IsDefined(typeof(SpawnFaction), factionDigit)
-            ? (SpawnFaction)factionDigit
-            : SpawnFaction.Default;
-
-        var levelSection = (encodedLifetime % 1) * 100;
-        level = (int)levelSection;
-
-        if (encodedLifetime > 1000 || level <= 0)
+        if (preFinalize != null)
         {
-            return false;
+            PendingCallbacks[marker] = new PendingSpawnCallback(count, lifetime, preFinalize);
         }
 
-        var checksumSection = (int)Math.Round((levelSection % 1) * 100);
-        if (checksumSection != level)
-        {
-            switch (level)
-            {
-                case 15:
-                case 40:
-                    checksumSection -= 1;
-                    break;
-                case 54:
-                    checksumSection += 1;
-                    break;
-            }
-        }
-
-        return checksumSection == level;
-    }
-
-    public static void SpawnUnit(PrefabGUID prefab, float3 position, int count, float minRange, float maxRange, float lifetime)
-    {
         Core.Server.GetExistingSystemManaged<UnitSpawnerUpdateSystem>().SpawnUnit(
             PlaceholderEntity,
             prefab,
@@ -65,13 +38,62 @@ internal static class FactionInfamySpawnUtility
             count,
             minRange,
             maxRange,
-            lifetime);
-    }
-}
+            marker);
 
-internal enum SpawnFaction
-{
-    Default = 0,
-    VampireHunters = 1,
-    WantedUnit = 2
+        return marker;
+    }
+
+    public static bool TryExecuteSpawnCallback(EntityManager entityManager, Entity entity, float lifetime)
+    {
+        var marker = (int)Math.Round(lifetime);
+        if (!PendingCallbacks.TryGetValue(marker, out var callback))
+        {
+            return false;
+        }
+
+        try
+        {
+            callback.Invoke(entityManager, entity, marker);
+        }
+        catch
+        {
+            // Suppress any callback errors to avoid breaking spawn flow.
+        }
+
+        if (callback.Decrement() <= 0)
+        {
+            PendingCallbacks.TryRemove(marker, out _);
+        }
+
+        return true;
+    }
+
+    public static void CancelSpawnCallback(int marker)
+    {
+        PendingCallbacks.TryRemove(marker, out _);
+    }
+
+    private sealed class PendingSpawnCallback
+    {
+        private int _remaining;
+        private readonly float _lifetime;
+        private readonly Action<EntityManager, Entity, int, float> _callback;
+
+        public PendingSpawnCallback(int remaining, float lifetime, Action<EntityManager, Entity, int, float> callback)
+        {
+            _remaining = Math.Max(1, remaining);
+            _lifetime = lifetime;
+            _callback = callback;
+        }
+
+        public int Decrement()
+        {
+            return System.Threading.Interlocked.Decrement(ref _remaining);
+        }
+
+        public void Invoke(EntityManager entityManager, Entity entity, int marker)
+        {
+            _callback(entityManager, entity, marker, _lifetime);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- generate dedicated spawn markers for ambush callbacks instead of encoding data in the lifetime value
- finalize ambush scaling and registration directly from the spawn callback while keeping a fallback path for missed callbacks
- update the UnitSpawner react patch to avoid double-processing when the callback has already run

## Testing
- `dotnet build VeinWares.SubtleByte.sln` *(fails: dotnet is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68f2acf3f7208327bf87e5df3d35a555