### PR TITLE
Apply visual buffs to faction ambush spawns

### DIFF
--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyAmbushService.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyAmbushService.cs
@@ -123,6 +123,23 @@ internal static class FactionInfamyAmbushService
             })
     };
 
+    private static readonly PrefabGUID ManticoreVisual = new(1670636401);
+    private static readonly PrefabGUID DraculaVisual = new(1199823151);
+    private static readonly PrefabGUID MonsterVisual = new(-2067402784);
+    private static readonly PrefabGUID SolarusVisual = new(178225731);
+    private static readonly PrefabGUID MegaraVisual = new(-2104035188);
+
+    private static readonly Dictionary<string, PrefabGUID> FactionVisualBuffs = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Bandits"] = ManticoreVisual,
+        ["Blackfangs"] = DraculaVisual,
+        ["Militia"] = SolarusVisual,
+        ["Gloomrot"] = MegaraVisual,
+        ["Legion"] = MonsterVisual,
+        ["Undead"] = MonsterVisual,
+        ["Werewolf"] = ManticoreVisual
+    };
+
     private static ManualLogSource? _log;
     private static readonly System.Random Random = new();
     private static bool _initialized;
@@ -632,6 +649,11 @@ internal static class FactionInfamyAmbushService
         }
 
         ApplyAmbushScaling(entityManager, entity, pending.UnitLevel, multipliers);
+
+        if (FactionVisualBuffs.TryGetValue(pending.FactionId, out var visualBuff))
+        {
+            entity.TryApplyVisualBuff(visualBuff);
+        }
 
         if (!entityManager.HasComponent<DestroyWhenDisabled>(entity))
         {

--- a/VeinWares.SubtleByte/Utilities/Buffs.cs
+++ b/VeinWares.SubtleByte/Utilities/Buffs.cs
@@ -39,34 +39,56 @@ namespace VeinWares.SubtleByte.Utilities
             return false;
         }
 
-        public static void TryApplyPermanentBuff(this Entity player, PrefabGUID buffPrefab)
+        public static bool TryApplyVisualBuff(this Entity entity, PrefabGUID buffPrefab)
         {
-            if (player.TryApplyAndGetBuff(buffPrefab, out Entity buffEntity))
+            Entity buffEntity;
+            if (!entity.TryApplyAndGetBuff(buffPrefab, out buffEntity))
             {
-                if (buffEntity.Has<ApplyBuffOnGameplayEvent>()) buffEntity.Remove<ApplyBuffOnGameplayEvent>();
-                if (buffEntity.Has<RemoveBuffOnGameplayEvent>()) buffEntity.Remove<RemoveBuffOnGameplayEvent>();
-                if (buffEntity.Has<RemoveBuffOnGameplayEventEntry>()) buffEntity.Remove<RemoveBuffOnGameplayEventEntry>();
-                if (buffEntity.Has<CreateGameplayEventsOnSpawn>()) buffEntity.Remove<CreateGameplayEventsOnSpawn>();
-                if (buffEntity.Has<GameplayEventListeners>()) buffEntity.Remove<GameplayEventListeners>();
-                if (buffEntity.Has<DealDamageOnGameplayEvent>()) buffEntity.Remove<DealDamageOnGameplayEvent>();
-                if (buffEntity.Has<HealOnGameplayEvent>()) buffEntity.Remove<HealOnGameplayEvent>();
-                if (buffEntity.Has<DestroyOnGameplayEvent>()) buffEntity.Remove<DestroyOnGameplayEvent>();
-                if (buffEntity.Has<WeakenBuff>()) buffEntity.Remove<WeakenBuff>();
-                if (buffEntity.Has<AmplifyBuff>()) buffEntity.Remove<AmplifyBuff>();
-                if (buffEntity.Has<ReplaceAbilityOnSlotBuff>()) buffEntity.Remove<ReplaceAbilityOnSlotBuff>();
-                if (buffEntity.Has<ModifyMovementSpeedBuff>()) buffEntity.Remove<ModifyMovementSpeedBuff>();
-                if (buffEntity.Has<BloodBuffScript_ChanceToResetCooldown>()) buffEntity.Remove<BloodBuffScript_ChanceToResetCooldown>();
-                buffEntity.Add<Buff_Persists_Through_Death>();
-
-                if (buffEntity.Has<LifeTime>())
+                if (!entity.TryGetBuff(buffPrefab, out buffEntity))
                 {
-                    buffEntity.With((ref LifeTime lifeTime) =>
-                    {
-                        lifeTime.Duration = 0f;
-                        lifeTime.EndAction = LifeTimeEndAction.None;
-                    });
+                    return false;
                 }
             }
+
+            if (!buffEntity.Exists())
+            {
+                return false;
+            }
+
+            if (buffEntity.Has<ApplyBuffOnGameplayEvent>()) buffEntity.Remove<ApplyBuffOnGameplayEvent>();
+            if (buffEntity.Has<RemoveBuffOnGameplayEvent>()) buffEntity.Remove<RemoveBuffOnGameplayEvent>();
+            if (buffEntity.Has<RemoveBuffOnGameplayEventEntry>()) buffEntity.Remove<RemoveBuffOnGameplayEventEntry>();
+            if (buffEntity.Has<CreateGameplayEventsOnSpawn>()) buffEntity.Remove<CreateGameplayEventsOnSpawn>();
+            if (buffEntity.Has<GameplayEventListeners>()) buffEntity.Remove<GameplayEventListeners>();
+            if (buffEntity.Has<DealDamageOnGameplayEvent>()) buffEntity.Remove<DealDamageOnGameplayEvent>();
+            if (buffEntity.Has<HealOnGameplayEvent>()) buffEntity.Remove<HealOnGameplayEvent>();
+            if (buffEntity.Has<DestroyOnGameplayEvent>()) buffEntity.Remove<DestroyOnGameplayEvent>();
+            if (buffEntity.Has<WeakenBuff>()) buffEntity.Remove<WeakenBuff>();
+            if (buffEntity.Has<AmplifyBuff>()) buffEntity.Remove<AmplifyBuff>();
+            if (buffEntity.Has<ReplaceAbilityOnSlotBuff>()) buffEntity.Remove<ReplaceAbilityOnSlotBuff>();
+            if (buffEntity.Has<ModifyMovementSpeedBuff>()) buffEntity.Remove<ModifyMovementSpeedBuff>();
+            if (buffEntity.Has<BloodBuffScript_ChanceToResetCooldown>()) buffEntity.Remove<BloodBuffScript_ChanceToResetCooldown>();
+
+            if (!buffEntity.Has<Buff_Persists_Through_Death>())
+            {
+                buffEntity.Add<Buff_Persists_Through_Death>();
+            }
+
+            if (buffEntity.Has<LifeTime>())
+            {
+                buffEntity.With((ref LifeTime lifeTime) =>
+                {
+                    lifeTime.Duration = 0f;
+                    lifeTime.EndAction = LifeTimeEndAction.None;
+                });
+            }
+
+            return true;
+        }
+
+        public static void TryApplyPermanentBuff(this Entity player, PrefabGUID buffPrefab)
+        {
+            player.TryApplyVisualBuff(buffPrefab);
         }
 
 


### PR DESCRIPTION
## Summary
- add a reusable helper for applying permanent visual buffs via the Buffs utility
- map each ambush faction to its chosen cosmetic buff prefab
- apply the faction-specific visual buff when finalizing ambush spawns

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f69cd757388327b9a433e44e0c81c1