### PR TITLE
Add faction infamy tier notifications with colorized chat support

### DIFF
--- a/VeinWares.SubtleByte/Config/FactionInfamyAmbushChat.schema.json
+++ b/VeinWares.SubtleByte/Config/FactionInfamyAmbushChat.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "FactionInfamyAmbushChat",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "defaultColor": {
+      "type": "string",
+      "pattern": "^#?[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$"
+    },
+    "defaultTierMessages": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[1-5]$": {
+          "type": "string"
+        }
+      }
+    },
+    "factions": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "color": {
+            "type": "string",
+            "pattern": "^#?[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$"
+          },
+          "tierMessages": {
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+              "^[1-5]$": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "defaultColor",
+    "defaultTierMessages",
+    "factions"
+  ]
+}

--- a/VeinWares.SubtleByte/Models/FactionInfamy/PlayerHateData.cs
+++ b/VeinWares.SubtleByte/Models/FactionInfamy/PlayerHateData.cs
@@ -41,7 +41,7 @@ internal sealed class PlayerHateData
         return result;
     }
 
-    public bool RunCooldown(float decayPerSecond, float deltaSeconds, float removalThreshold)
+    public bool RunCooldown(float decayPerSecond, float deltaSeconds, float removalThreshold, float maximumHate)
     {
         if (_factionHate.Count == 0 || decayPerSecond <= 0f || deltaSeconds <= 0f)
         {
@@ -74,6 +74,7 @@ internal sealed class PlayerHateData
 
             entry.Hate = newHate;
             entry.LastUpdated = DateTime.UtcNow;
+            entry.LastAnnouncedTier = FactionInfamyTierHelper.CalculateTier(newHate, maximumHate);
             updates.Add(new KeyValuePair<string, HateEntry>(pair.Key, entry));
 
             if (newHate <= removalThreshold)
@@ -106,4 +107,6 @@ internal struct HateEntry
     public DateTime LastUpdated { get; set; }
 
     public DateTime LastAmbush { get; set; }
+
+    public int LastAnnouncedTier { get; set; }
 }

--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyAmbushService.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyAmbushService.cs
@@ -615,15 +615,7 @@ internal static class FactionInfamyAmbushService
 
     private static AmbushDifficulty EvaluateDifficulty(float hateValue)
     {
-        var maximumHate = Math.Max(1f, FactionInfamySystem.MaximumHate);
-        var normalized = Math.Clamp(hateValue / maximumHate, 0f, 1f);
-        var bucket = (int)Math.Floor(normalized * 5.0) + 1;
-        if (normalized >= 0.999f)
-        {
-            bucket = 5;
-        }
-
-        bucket = Math.Clamp(bucket, 1, 5);
+        var bucket = FactionInfamyTierHelper.CalculateTier(hateValue, FactionInfamySystem.MaximumHate);
 
         var offset = bucket switch
         {

--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyPersistence.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyPersistence.cs
@@ -95,11 +95,18 @@ internal static class FactionInfamyPersistence
 
         foreach (var faction in record.Factions)
         {
+            var factionRecord = faction.Value;
+            if (factionRecord is null)
+            {
+                continue;
+            }
+
             var entry = new HateEntry
             {
-                Hate = faction.Value.Hate,
-                LastAmbush = faction.Value.LastAmbush,
-                LastUpdated = faction.Value.LastUpdated
+                Hate = factionRecord.Hate,
+                LastAmbush = factionRecord.LastAmbush,
+                LastUpdated = factionRecord.LastUpdated,
+                LastAnnouncedTier = factionRecord.LastAnnouncedTier
             };
             data.SetHate(faction.Key, entry);
         }
@@ -152,4 +159,6 @@ internal sealed class HateEntryRecord
     public DateTime LastUpdated { get; set; }
 
     public DateTime LastAmbush { get; set; }
+
+    public int LastAnnouncedTier { get; set; }
 }

--- a/VeinWares.SubtleByte/Utilities/FactionInfamyTierHelper.cs
+++ b/VeinWares.SubtleByte/Utilities/FactionInfamyTierHelper.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace VeinWares.SubtleByte.Utilities;
+
+internal static class FactionInfamyTierHelper
+{
+    private const int MaxTier = 5;
+
+    public static int CalculateTier(float hateValue, float maximumHate)
+    {
+        var max = Math.Max(1f, maximumHate);
+        if (max <= 0f)
+        {
+            return 1;
+        }
+
+        var normalized = Math.Clamp(hateValue / max, 0f, 1f);
+        var bucket = (int)Math.Floor(normalized * MaxTier) + 1;
+        if (normalized >= 0.999f)
+        {
+            bucket = MaxTier;
+        }
+
+        return Math.Clamp(bucket, 1, MaxTier);
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared helper for determining faction infamy tiers and persist the last announced tier per faction
- send immediate colored chat notifications when a player reaches a higher hate tier and reuse the helper for ambush difficulty
- expand the ambush chat configuration with per-tier templates, faction colors, and a JSON schema describing the format

## Testing
- dotnet build VeinWares.SubtleByte/VeinWares.SubtleByte.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f7e0f6ae4c83279106fb3298cc12fa