### PR TITLE
Add ghost seasonal reinforcements and follow-up wave controls

### DIFF
--- a/VeinWares.SubtleByte/Config/FactionInfamyConfig.cs
+++ b/VeinWares.SubtleByte/Config/FactionInfamyConfig.cs
@@ -22,6 +22,9 @@ internal static class FactionInfamyConfig
     private static ConfigEntry<int> _halloweenScarecrowMaximum;
     private static ConfigEntry<int> _halloweenScarecrowRareMultiplier;
     private static ConfigEntry<int> _halloweenScarecrowRareChancePercent;
+    private static ConfigEntry<int> _seasonalFollowUpChancePercent;
+    private static ConfigEntry<int> _seasonalFollowUpMinimum;
+    private static ConfigEntry<int> _seasonalFollowUpMaximum;
     private static ConfigEntry<bool> _enableEliteAmbush;
     private static ConfigEntry<float> _eliteHealthMultiplier;
     private static ConfigEntry<float> _eliteDamageReductionMultiplier;
@@ -149,6 +152,24 @@ internal static class FactionInfamyConfig
             5,
             "Percent chance that the scarecrow roll will be multiplied by the rare multiplier value. Set to zero to disable the rare roll.");
 
+        _seasonalFollowUpChancePercent = configFile.Bind(
+            "Faction Infamy",
+            "Halloween Follow-Up Wave Chance Percent",
+            0,
+            "Percent chance that a second seasonal ambush wave spawns after the core squad. Set to zero to disable follow-up waves.");
+
+        _seasonalFollowUpMinimum = configFile.Bind(
+            "Faction Infamy",
+            "Halloween Follow-Up Wave Minimum",
+            1,
+            "Minimum number of shared seasonal units to spawn in the follow-up wave when enabled.");
+
+        _seasonalFollowUpMaximum = configFile.Bind(
+            "Faction Infamy",
+            "Halloween Follow-Up Wave Maximum",
+            2,
+            "Maximum number of shared seasonal units to spawn in the follow-up wave when enabled. Values below the minimum will be clamped.");
+
         _enableEliteAmbush = configFile.Bind(
             "Faction Infamy - Elite Ambush",
             "Enable Elite Ambush",
@@ -273,6 +294,9 @@ internal static class FactionInfamyConfig
 
         var scarecrowMin = Math.Max(0, _halloweenScarecrowMinimum.Value);
         var scarecrowMax = Math.Max(scarecrowMin, _halloweenScarecrowMaximum.Value);
+        var followUpChance = Math.Clamp(_seasonalFollowUpChancePercent.Value, 0, 100);
+        var followUpMin = Math.Max(0, _seasonalFollowUpMinimum.Value);
+        var followUpMax = Math.Max(followUpMin, _seasonalFollowUpMaximum.Value);
 
         var eliteHealth = Math.Max(0f, _eliteHealthMultiplier.Value);
         var eliteDamageReduction = Math.Max(0f, _eliteDamageReductionMultiplier.Value);
@@ -309,6 +333,9 @@ internal static class FactionInfamyConfig
             scarecrowMax,
             Math.Max(1, _halloweenScarecrowRareMultiplier.Value),
             Math.Clamp(_halloweenScarecrowRareChancePercent.Value, 0, 100),
+            followUpChance,
+            followUpMin,
+            followUpMax,
             _enableEliteAmbush.Value,
             eliteHealth,
             eliteDamageReduction,
@@ -416,6 +443,26 @@ internal static class FactionInfamyConfig
             _halloweenScarecrowRareChancePercent.Value = 100;
         }
 
+        if (_seasonalFollowUpChancePercent.Value < 0)
+        {
+            _seasonalFollowUpChancePercent.Value = 0;
+        }
+
+        if (_seasonalFollowUpChancePercent.Value > 100)
+        {
+            _seasonalFollowUpChancePercent.Value = 100;
+        }
+
+        if (_seasonalFollowUpMinimum.Value < 0)
+        {
+            _seasonalFollowUpMinimum.Value = 0;
+        }
+
+        if (_seasonalFollowUpMaximum.Value < _seasonalFollowUpMinimum.Value)
+        {
+            _seasonalFollowUpMaximum.Value = _seasonalFollowUpMinimum.Value;
+        }
+
         if (_eliteHealthMultiplier.Value < 0f)
         {
             _eliteHealthMultiplier.Value = 0f;
@@ -515,6 +562,9 @@ internal readonly record struct FactionInfamyConfigSnapshot(
     int HalloweenScarecrowMaximum,
     int HalloweenScarecrowRareMultiplier,
     int HalloweenScarecrowRareChancePercent,
+    int SeasonalFollowUpChancePercent,
+    int SeasonalFollowUpMinimum,
+    int SeasonalFollowUpMaximum,
     bool EnableEliteAmbush,
     float EliteHealthMultiplier,
     float EliteDamageReductionMultiplier,

--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamySystem.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamySystem.cs
@@ -29,6 +29,9 @@ internal static class FactionInfamySystem
     private static int _halloweenScarecrowMaximum;
     private static int _halloweenScarecrowRareMultiplier;
     private static int _halloweenScarecrowRareChancePercent;
+    private static int _seasonalFollowUpChancePercent;
+    private static int _seasonalFollowUpMinimum;
+    private static int _seasonalFollowUpMaximum;
     private static bool _enableEliteAmbush;
     private static bool _enableAmbushKnockbackResistance;
     private static float _eliteHealthMultiplier;
@@ -69,6 +72,12 @@ internal static class FactionInfamySystem
     internal static int HalloweenScarecrowRareMultiplier => _halloweenScarecrowRareMultiplier;
 
     internal static int HalloweenScarecrowRareChancePercent => _halloweenScarecrowRareChancePercent;
+
+    internal static int SeasonalFollowUpChancePercent => _seasonalFollowUpChancePercent;
+
+    internal static int SeasonalFollowUpMinimum => _seasonalFollowUpMinimum;
+
+    internal static int SeasonalFollowUpMaximum => _seasonalFollowUpMaximum;
 
     internal static bool EliteAmbushEnabled => _enableEliteAmbush;
 
@@ -129,6 +138,9 @@ internal static class FactionInfamySystem
         _halloweenScarecrowMaximum = config.HalloweenScarecrowMaximum;
         _halloweenScarecrowRareMultiplier = config.HalloweenScarecrowRareMultiplier;
         _halloweenScarecrowRareChancePercent = config.HalloweenScarecrowRareChancePercent;
+        _seasonalFollowUpChancePercent = config.SeasonalFollowUpChancePercent;
+        _seasonalFollowUpMinimum = config.SeasonalFollowUpMinimum;
+        _seasonalFollowUpMaximum = config.SeasonalFollowUpMaximum;
         _enableEliteAmbush = config.EnableEliteAmbush;
         _enableAmbushKnockbackResistance = config.EnableAmbushKnockbackResistance;
         _eliteHealthMultiplier = config.EliteHealthMultiplier;


### PR DESCRIPTION
## Summary
- add ghost seasonal ambush definitions and include them across all faction seasonal loadouts
- extend the ambush spawning pipeline to stage configurable follow-up waves and ensure they contribute to hate relief
- expose the follow-up wave chance and shared counts in the faction infamy configuration snapshot

## Testing
- `dotnet build VeinWares.SubtleByte.sln` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f7e5bc1e088327bc06879483ce6c4d