### PR TITLE
Guard seasonal ghosts on zero scarecrow roll

### DIFF
--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyAmbushService.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyAmbushService.cs
@@ -451,6 +451,11 @@ internal static class FactionInfamyAmbushService
         }
 
         var scarecrowCount = RollHalloweenScarecrowCount();
+        if (scarecrowCount <= 0)
+        {
+            return new AmbushSpawnPlan(requests, followUps);
+        }
+
         var followUpCount = RollHalloweenFollowUpCount();
 
         foreach (var seasonal in seasonalUnits)


### PR DESCRIPTION
## Summary
- restore the zero-scarecrow guard when scheduling halloween seasonal units
- prevent the new ghost ambush definitions from spawning when the scarecrow roll is zero

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68f7ea1a6aec8327aff6a8ad766a771b