### PR TITLE
Add elite ambush representative bonus controls

### DIFF
--- a/VeinWares.SubtleByte/Config/FactionInfamyConfig.cs
+++ b/VeinWares.SubtleByte/Config/FactionInfamyConfig.cs
@@ -35,13 +35,21 @@ internal static class FactionInfamyConfig
     private static ConfigEntry<float> _eliteMoveSpeedMultiplier;
     private static ConfigEntry<float> _eliteKnockbackResistanceMultiplier;
     private static ConfigEntry<float> _eliteRepresentativeHealthRatio;
+    private static ConfigEntry<float> _eliteRepresentativeHealthAdditive;
     private static ConfigEntry<float> _eliteRepresentativeDamageReductionRatio;
+    private static ConfigEntry<float> _eliteRepresentativeDamageReductionAdditive;
     private static ConfigEntry<float> _eliteRepresentativeResistanceRatio;
+    private static ConfigEntry<float> _eliteRepresentativeResistanceAdditive;
     private static ConfigEntry<float> _eliteRepresentativePowerRatio;
+    private static ConfigEntry<float> _eliteRepresentativePowerAdditive;
     private static ConfigEntry<float> _eliteRepresentativeAttackSpeedRatio;
+    private static ConfigEntry<float> _eliteRepresentativeAttackSpeedAdditive;
     private static ConfigEntry<float> _eliteRepresentativeSpellSpeedRatio;
+    private static ConfigEntry<float> _eliteRepresentativeSpellSpeedAdditive;
     private static ConfigEntry<float> _eliteRepresentativeMoveSpeedRatio;
+    private static ConfigEntry<float> _eliteRepresentativeMoveSpeedAdditive;
     private static ConfigEntry<float> _eliteRepresentativeKnockbackResistanceRatio;
+    private static ConfigEntry<float> _eliteRepresentativeKnockbackResistanceAdditive;
     private static ConfigEntry<bool> _enableAmbushKnockbackResistance;
 
     public static void Initialize(ConfigFile configFile)
@@ -230,11 +238,23 @@ internal static class FactionInfamyConfig
             1.0f,
             "Additional multiplier applied to elite representative health on top of the base elite multiplier.");
 
+        _eliteRepresentativeHealthAdditive = configFile.Bind(
+            "Faction Infamy - Elite Ambush",
+            "Elite Representative Health Bonus",
+            0.0f,
+            "Flat bonus applied to elite representative health multipliers after the squad multiplier and ratio are applied.");
+
         _eliteRepresentativeDamageReductionRatio = configFile.Bind(
             "Faction Infamy - Elite Ambush",
             "Elite Representative Damage Reduction Ratio",
             1.0f,
             "Additional multiplier applied to elite representative damage reduction on top of the base elite multiplier.");
+
+        _eliteRepresentativeDamageReductionAdditive = configFile.Bind(
+            "Faction Infamy - Elite Ambush",
+            "Elite Representative Damage Reduction Bonus",
+            0.0f,
+            "Flat bonus applied to elite representative damage reduction multipliers after the squad multiplier and ratio are applied.");
 
         _eliteRepresentativeResistanceRatio = configFile.Bind(
             "Faction Infamy - Elite Ambush",
@@ -242,11 +262,23 @@ internal static class FactionInfamyConfig
             1.0f,
             "Additional multiplier applied to elite representative resistances on top of the base elite multiplier.");
 
+        _eliteRepresentativeResistanceAdditive = configFile.Bind(
+            "Faction Infamy - Elite Ambush",
+            "Elite Representative Resistance Bonus",
+            0.0f,
+            "Flat bonus applied to elite representative resistance multipliers after the squad multiplier and ratio are applied.");
+
         _eliteRepresentativePowerRatio = configFile.Bind(
             "Faction Infamy - Elite Ambush",
             "Elite Representative Power Ratio",
             1.0f,
             "Additional multiplier applied to elite representative power on top of the base elite multiplier.");
+
+        _eliteRepresentativePowerAdditive = configFile.Bind(
+            "Faction Infamy - Elite Ambush",
+            "Elite Representative Power Bonus",
+            0.0f,
+            "Flat bonus applied to elite representative power multipliers after the squad multiplier and ratio are applied.");
 
         _eliteRepresentativeAttackSpeedRatio = configFile.Bind(
             "Faction Infamy - Elite Ambush",
@@ -254,11 +286,23 @@ internal static class FactionInfamyConfig
             1.0f,
             "Additional multiplier applied to elite representative primary attack speed on top of the base elite multiplier.");
 
+        _eliteRepresentativeAttackSpeedAdditive = configFile.Bind(
+            "Faction Infamy - Elite Ambush",
+            "Elite Representative Attack Speed Bonus",
+            0.0f,
+            "Flat bonus applied to elite representative attack speed multipliers after the squad multiplier and ratio are applied.");
+
         _eliteRepresentativeSpellSpeedRatio = configFile.Bind(
             "Faction Infamy - Elite Ambush",
             "Elite Representative Spell Speed Ratio",
             1.0f,
             "Additional multiplier applied to elite representative spell speed on top of the base elite multiplier.");
+
+        _eliteRepresentativeSpellSpeedAdditive = configFile.Bind(
+            "Faction Infamy - Elite Ambush",
+            "Elite Representative Spell Speed Bonus",
+            0.0f,
+            "Flat bonus applied to elite representative spell speed multipliers after the squad multiplier and ratio are applied.");
 
         _eliteRepresentativeMoveSpeedRatio = configFile.Bind(
             "Faction Infamy - Elite Ambush",
@@ -266,11 +310,23 @@ internal static class FactionInfamyConfig
             1.0f,
             "Additional multiplier applied to elite representative movement speed on top of the base elite multiplier.");
 
+        _eliteRepresentativeMoveSpeedAdditive = configFile.Bind(
+            "Faction Infamy - Elite Ambush",
+            "Elite Representative Move Speed Bonus",
+            0.0f,
+            "Flat bonus applied to elite representative move speed multipliers after the squad multiplier and ratio are applied.");
+
         _eliteRepresentativeKnockbackResistanceRatio = configFile.Bind(
             "Faction Infamy - Elite Ambush",
             "Elite Representative Knockback Resistance Ratio",
             1.0f,
             "Additional multiplier applied to elite representative knockback resistance on top of the base elite multiplier.");
+
+        _eliteRepresentativeKnockbackResistanceAdditive = configFile.Bind(
+            "Faction Infamy - Elite Ambush",
+            "Elite Representative Knockback Resistance Bonus",
+            0.0f,
+            "Flat bonus applied to elite representative knockback resistance multipliers after the squad multiplier and ratio are applied.");
 
         _enableAmbushKnockbackResistance = configFile.Bind(
             "Faction Infamy - Elite Ambush",
@@ -308,13 +364,21 @@ internal static class FactionInfamyConfig
         var eliteKnockback = Math.Max(0f, _eliteKnockbackResistanceMultiplier.Value);
 
         var eliteRepHealth = Math.Max(0f, _eliteRepresentativeHealthRatio.Value);
+        var eliteRepHealthAdd = Math.Max(0f, _eliteRepresentativeHealthAdditive.Value);
         var eliteRepDamageReduction = Math.Max(0f, _eliteRepresentativeDamageReductionRatio.Value);
+        var eliteRepDamageReductionAdd = Math.Max(0f, _eliteRepresentativeDamageReductionAdditive.Value);
         var eliteRepResistance = Math.Max(0f, _eliteRepresentativeResistanceRatio.Value);
+        var eliteRepResistanceAdd = Math.Max(0f, _eliteRepresentativeResistanceAdditive.Value);
         var eliteRepPower = Math.Max(0f, _eliteRepresentativePowerRatio.Value);
+        var eliteRepPowerAdd = Math.Max(0f, _eliteRepresentativePowerAdditive.Value);
         var eliteRepAttackSpeed = Math.Max(0f, _eliteRepresentativeAttackSpeedRatio.Value);
+        var eliteRepAttackSpeedAdd = Math.Max(0f, _eliteRepresentativeAttackSpeedAdditive.Value);
         var eliteRepSpellSpeed = Math.Max(0f, _eliteRepresentativeSpellSpeedRatio.Value);
+        var eliteRepSpellSpeedAdd = Math.Max(0f, _eliteRepresentativeSpellSpeedAdditive.Value);
         var eliteRepMoveSpeed = Math.Max(0f, _eliteRepresentativeMoveSpeedRatio.Value);
+        var eliteRepMoveSpeedAdd = Math.Max(0f, _eliteRepresentativeMoveSpeedAdditive.Value);
         var eliteRepKnockback = Math.Max(0f, _eliteRepresentativeKnockbackResistanceRatio.Value);
+        var eliteRepKnockbackAdd = Math.Max(0f, _eliteRepresentativeKnockbackResistanceAdditive.Value);
 
         return new FactionInfamyConfigSnapshot(
             Math.Max(0f, _hateGainMultiplier.Value),
@@ -346,13 +410,21 @@ internal static class FactionInfamyConfig
             eliteMoveSpeed,
             eliteKnockback,
             eliteRepHealth,
+            eliteRepHealthAdd,
             eliteRepDamageReduction,
+            eliteRepDamageReductionAdd,
             eliteRepResistance,
+            eliteRepResistanceAdd,
             eliteRepPower,
+            eliteRepPowerAdd,
             eliteRepAttackSpeed,
+            eliteRepAttackSpeedAdd,
             eliteRepSpellSpeed,
+            eliteRepSpellSpeedAdd,
             eliteRepMoveSpeed,
+            eliteRepMoveSpeedAdd,
             eliteRepKnockback,
+            eliteRepKnockbackAdd,
             _enableAmbushKnockbackResistance.Value);
     }
 
@@ -508,9 +580,19 @@ internal static class FactionInfamyConfig
             _eliteRepresentativeHealthRatio.Value = 0f;
         }
 
+        if (_eliteRepresentativeHealthAdditive.Value < 0f)
+        {
+            _eliteRepresentativeHealthAdditive.Value = 0f;
+        }
+
         if (_eliteRepresentativeDamageReductionRatio.Value < 0f)
         {
             _eliteRepresentativeDamageReductionRatio.Value = 0f;
+        }
+
+        if (_eliteRepresentativeDamageReductionAdditive.Value < 0f)
+        {
+            _eliteRepresentativeDamageReductionAdditive.Value = 0f;
         }
 
         if (_eliteRepresentativeResistanceRatio.Value < 0f)
@@ -518,9 +600,19 @@ internal static class FactionInfamyConfig
             _eliteRepresentativeResistanceRatio.Value = 0f;
         }
 
+        if (_eliteRepresentativeResistanceAdditive.Value < 0f)
+        {
+            _eliteRepresentativeResistanceAdditive.Value = 0f;
+        }
+
         if (_eliteRepresentativePowerRatio.Value < 0f)
         {
             _eliteRepresentativePowerRatio.Value = 0f;
+        }
+
+        if (_eliteRepresentativePowerAdditive.Value < 0f)
+        {
+            _eliteRepresentativePowerAdditive.Value = 0f;
         }
 
         if (_eliteRepresentativeAttackSpeedRatio.Value < 0f)
@@ -528,9 +620,19 @@ internal static class FactionInfamyConfig
             _eliteRepresentativeAttackSpeedRatio.Value = 0f;
         }
 
+        if (_eliteRepresentativeAttackSpeedAdditive.Value < 0f)
+        {
+            _eliteRepresentativeAttackSpeedAdditive.Value = 0f;
+        }
+
         if (_eliteRepresentativeSpellSpeedRatio.Value < 0f)
         {
             _eliteRepresentativeSpellSpeedRatio.Value = 0f;
+        }
+
+        if (_eliteRepresentativeSpellSpeedAdditive.Value < 0f)
+        {
+            _eliteRepresentativeSpellSpeedAdditive.Value = 0f;
         }
 
         if (_eliteRepresentativeMoveSpeedRatio.Value < 0f)
@@ -538,9 +640,19 @@ internal static class FactionInfamyConfig
             _eliteRepresentativeMoveSpeedRatio.Value = 0f;
         }
 
+        if (_eliteRepresentativeMoveSpeedAdditive.Value < 0f)
+        {
+            _eliteRepresentativeMoveSpeedAdditive.Value = 0f;
+        }
+
         if (_eliteRepresentativeKnockbackResistanceRatio.Value < 0f)
         {
             _eliteRepresentativeKnockbackResistanceRatio.Value = 0f;
+        }
+
+        if (_eliteRepresentativeKnockbackResistanceAdditive.Value < 0f)
+        {
+            _eliteRepresentativeKnockbackResistanceAdditive.Value = 0f;
         }
     }
 }
@@ -575,11 +687,19 @@ internal readonly record struct FactionInfamyConfigSnapshot(
     float EliteMoveSpeedMultiplier,
     float EliteKnockbackResistanceMultiplier,
     float EliteRepresentativeHealthRatio,
+    float EliteRepresentativeHealthAdditive,
     float EliteRepresentativeDamageReductionRatio,
+    float EliteRepresentativeDamageReductionAdditive,
     float EliteRepresentativeResistanceRatio,
+    float EliteRepresentativeResistanceAdditive,
     float EliteRepresentativePowerRatio,
+    float EliteRepresentativePowerAdditive,
     float EliteRepresentativeAttackSpeedRatio,
+    float EliteRepresentativeAttackSpeedAdditive,
     float EliteRepresentativeSpellSpeedRatio,
+    float EliteRepresentativeSpellSpeedAdditive,
     float EliteRepresentativeMoveSpeedRatio,
+    float EliteRepresentativeMoveSpeedAdditive,
     float EliteRepresentativeKnockbackResistanceRatio,
+    float EliteRepresentativeKnockbackResistanceAdditive,
     bool EnableAmbushKnockbackResistance);

--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyAmbushService.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyAmbushService.cs
@@ -1287,27 +1287,53 @@ internal static class FactionInfamyAmbushService
             return Math.Abs(value - 1f) <= Epsilon;
         }
 
-        private static float ResolveMultiplier(float baseMultiplier, float representativeRatio, bool isRepresentative)
-        {
-            var resolved = Math.Max(0f, baseMultiplier);
-            if (isRepresentative)
-            {
-                resolved *= Math.Max(0f, representativeRatio);
-            }
-
-            return resolved;
-        }
-
         public static AmbushStatMultipliers Create(bool isRepresentative)
         {
-            var health = ResolveMultiplier(FactionInfamySystem.EliteHealthMultiplier, FactionInfamySystem.EliteRepresentativeHealthRatio, isRepresentative);
-            var damageReduction = ResolveMultiplier(FactionInfamySystem.EliteDamageReductionMultiplier, FactionInfamySystem.EliteRepresentativeDamageReductionRatio, isRepresentative);
-            var resistance = ResolveMultiplier(FactionInfamySystem.EliteResistanceMultiplier, FactionInfamySystem.EliteRepresentativeResistanceRatio, isRepresentative);
-            var power = ResolveMultiplier(FactionInfamySystem.ElitePowerMultiplier, FactionInfamySystem.EliteRepresentativePowerRatio, isRepresentative);
-            var attackSpeed = ResolveMultiplier(FactionInfamySystem.EliteAttackSpeedMultiplier, FactionInfamySystem.EliteRepresentativeAttackSpeedRatio, isRepresentative);
-            var spellSpeed = ResolveMultiplier(FactionInfamySystem.EliteSpellSpeedMultiplier, FactionInfamySystem.EliteRepresentativeSpellSpeedRatio, isRepresentative);
-            var moveSpeed = ResolveMultiplier(FactionInfamySystem.EliteMoveSpeedMultiplier, FactionInfamySystem.EliteRepresentativeMoveSpeedRatio, isRepresentative);
-            var knockback = ResolveMultiplier(FactionInfamySystem.EliteKnockbackResistanceMultiplier, FactionInfamySystem.EliteRepresentativeKnockbackResistanceRatio, isRepresentative);
+            if (!FactionInfamySystem.EliteAmbushEnabled)
+            {
+                return Identity;
+            }
+
+            var health = ResolveMultiplier(
+                FactionInfamySystem.EliteHealthMultiplier,
+                FactionInfamySystem.EliteRepresentativeHealthRatio,
+                FactionInfamySystem.EliteRepresentativeHealthAdditive,
+                isRepresentative);
+            var damageReduction = ResolveMultiplier(
+                FactionInfamySystem.EliteDamageReductionMultiplier,
+                FactionInfamySystem.EliteRepresentativeDamageReductionRatio,
+                FactionInfamySystem.EliteRepresentativeDamageReductionAdditive,
+                isRepresentative);
+            var resistance = ResolveMultiplier(
+                FactionInfamySystem.EliteResistanceMultiplier,
+                FactionInfamySystem.EliteRepresentativeResistanceRatio,
+                FactionInfamySystem.EliteRepresentativeResistanceAdditive,
+                isRepresentative);
+            var power = ResolveMultiplier(
+                FactionInfamySystem.ElitePowerMultiplier,
+                FactionInfamySystem.EliteRepresentativePowerRatio,
+                FactionInfamySystem.EliteRepresentativePowerAdditive,
+                isRepresentative);
+            var attackSpeed = ResolveMultiplier(
+                FactionInfamySystem.EliteAttackSpeedMultiplier,
+                FactionInfamySystem.EliteRepresentativeAttackSpeedRatio,
+                FactionInfamySystem.EliteRepresentativeAttackSpeedAdditive,
+                isRepresentative);
+            var spellSpeed = ResolveMultiplier(
+                FactionInfamySystem.EliteSpellSpeedMultiplier,
+                FactionInfamySystem.EliteRepresentativeSpellSpeedRatio,
+                FactionInfamySystem.EliteRepresentativeSpellSpeedAdditive,
+                isRepresentative);
+            var moveSpeed = ResolveMultiplier(
+                FactionInfamySystem.EliteMoveSpeedMultiplier,
+                FactionInfamySystem.EliteRepresentativeMoveSpeedRatio,
+                FactionInfamySystem.EliteRepresentativeMoveSpeedAdditive,
+                isRepresentative);
+            var knockback = ResolveMultiplier(
+                FactionInfamySystem.EliteKnockbackResistanceMultiplier,
+                FactionInfamySystem.EliteRepresentativeKnockbackResistanceRatio,
+                FactionInfamySystem.EliteRepresentativeKnockbackResistanceAdditive,
+                isRepresentative);
             var applyKnockback = FactionInfamySystem.AmbushKnockbackResistanceEnabled && !IsApproximatelyOne(knockback);
 
             if (IsApproximatelyOne(health)
@@ -1335,6 +1361,26 @@ internal static class FactionInfamyAmbushService
         }
 
         public static AmbushStatMultipliers Identity { get; } = new(1f, 1f, 1f, 1f, 1f, 1f, 1f, 1f, false);
+
+        private static float ResolveMultiplier(
+            float squadMultiplier,
+            float representativeRatio,
+            float representativeAdditive,
+            bool isRepresentative)
+        {
+            var resolved = Math.Max(0f, squadMultiplier);
+
+            if (!isRepresentative)
+            {
+                return resolved;
+            }
+
+            var ratio = Math.Max(0f, representativeRatio);
+            var additive = Math.Max(0f, representativeAdditive);
+            resolved = resolved * ratio + additive;
+
+            return Math.Max(0f, resolved);
+        }
     }
 
     private readonly struct AmbushUnitDefinition

--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamySystem.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamySystem.cs
@@ -43,13 +43,21 @@ internal static class FactionInfamySystem
     private static float _eliteMoveSpeedMultiplier;
     private static float _eliteKnockbackResistanceMultiplier;
     private static float _eliteRepresentativeHealthRatio;
+    private static float _eliteRepresentativeHealthAdditive;
     private static float _eliteRepresentativeDamageReductionRatio;
+    private static float _eliteRepresentativeDamageReductionAdditive;
     private static float _eliteRepresentativeResistanceRatio;
+    private static float _eliteRepresentativeResistanceAdditive;
     private static float _eliteRepresentativePowerRatio;
+    private static float _eliteRepresentativePowerAdditive;
     private static float _eliteRepresentativeAttackSpeedRatio;
+    private static float _eliteRepresentativeAttackSpeedAdditive;
     private static float _eliteRepresentativeSpellSpeedRatio;
+    private static float _eliteRepresentativeSpellSpeedAdditive;
     private static float _eliteRepresentativeMoveSpeedRatio;
+    private static float _eliteRepresentativeMoveSpeedAdditive;
     private static float _eliteRepresentativeKnockbackResistanceRatio;
+    private static float _eliteRepresentativeKnockbackResistanceAdditive;
 
     public static bool Enabled => _initialized;
 
@@ -101,19 +109,35 @@ internal static class FactionInfamySystem
 
     internal static float EliteRepresentativeHealthRatio => _eliteRepresentativeHealthRatio;
 
+    internal static float EliteRepresentativeHealthAdditive => _eliteRepresentativeHealthAdditive;
+
     internal static float EliteRepresentativeDamageReductionRatio => _eliteRepresentativeDamageReductionRatio;
+
+    internal static float EliteRepresentativeDamageReductionAdditive => _eliteRepresentativeDamageReductionAdditive;
 
     internal static float EliteRepresentativeResistanceRatio => _eliteRepresentativeResistanceRatio;
 
+    internal static float EliteRepresentativeResistanceAdditive => _eliteRepresentativeResistanceAdditive;
+
     internal static float EliteRepresentativePowerRatio => _eliteRepresentativePowerRatio;
+
+    internal static float EliteRepresentativePowerAdditive => _eliteRepresentativePowerAdditive;
 
     internal static float EliteRepresentativeAttackSpeedRatio => _eliteRepresentativeAttackSpeedRatio;
 
+    internal static float EliteRepresentativeAttackSpeedAdditive => _eliteRepresentativeAttackSpeedAdditive;
+
     internal static float EliteRepresentativeSpellSpeedRatio => _eliteRepresentativeSpellSpeedRatio;
+
+    internal static float EliteRepresentativeSpellSpeedAdditive => _eliteRepresentativeSpellSpeedAdditive;
 
     internal static float EliteRepresentativeMoveSpeedRatio => _eliteRepresentativeMoveSpeedRatio;
 
+    internal static float EliteRepresentativeMoveSpeedAdditive => _eliteRepresentativeMoveSpeedAdditive;
+
     internal static float EliteRepresentativeKnockbackResistanceRatio => _eliteRepresentativeKnockbackResistanceRatio;
+
+    internal static float EliteRepresentativeKnockbackResistanceAdditive => _eliteRepresentativeKnockbackResistanceAdditive;
 
     public static int AutosaveBackupCount { get; private set; }
 
@@ -152,13 +176,21 @@ internal static class FactionInfamySystem
         _eliteMoveSpeedMultiplier = config.EliteMoveSpeedMultiplier;
         _eliteKnockbackResistanceMultiplier = config.EliteKnockbackResistanceMultiplier;
         _eliteRepresentativeHealthRatio = config.EliteRepresentativeHealthRatio;
+        _eliteRepresentativeHealthAdditive = config.EliteRepresentativeHealthAdditive;
         _eliteRepresentativeDamageReductionRatio = config.EliteRepresentativeDamageReductionRatio;
+        _eliteRepresentativeDamageReductionAdditive = config.EliteRepresentativeDamageReductionAdditive;
         _eliteRepresentativeResistanceRatio = config.EliteRepresentativeResistanceRatio;
+        _eliteRepresentativeResistanceAdditive = config.EliteRepresentativeResistanceAdditive;
         _eliteRepresentativePowerRatio = config.EliteRepresentativePowerRatio;
+        _eliteRepresentativePowerAdditive = config.EliteRepresentativePowerAdditive;
         _eliteRepresentativeAttackSpeedRatio = config.EliteRepresentativeAttackSpeedRatio;
+        _eliteRepresentativeAttackSpeedAdditive = config.EliteRepresentativeAttackSpeedAdditive;
         _eliteRepresentativeSpellSpeedRatio = config.EliteRepresentativeSpellSpeedRatio;
+        _eliteRepresentativeSpellSpeedAdditive = config.EliteRepresentativeSpellSpeedAdditive;
         _eliteRepresentativeMoveSpeedRatio = config.EliteRepresentativeMoveSpeedRatio;
+        _eliteRepresentativeMoveSpeedAdditive = config.EliteRepresentativeMoveSpeedAdditive;
         _eliteRepresentativeKnockbackResistanceRatio = config.EliteRepresentativeKnockbackResistanceRatio;
+        _eliteRepresentativeKnockbackResistanceAdditive = config.EliteRepresentativeKnockbackResistanceAdditive;
 
         PlayerHate.Clear();
         var loaded = FactionInfamyPersistence.Load();

--- a/docs/faction-infamy-elite-ambush.md
+++ b/docs/faction-infamy-elite-ambush.md
@@ -1,0 +1,30 @@
+# Elite ambush stat scaling options
+
+The Faction Infamy configuration now exposes more granular controls for elite ambush stat tuning.
+
+## Squad-wide multipliers
+
+The existing `Elite <Stat> Multiplier` entries continue to scale every member of an elite ambush squad whenever `Enable Elite Ambush` is true. These values default to `1.0` so existing configurations behave exactly as before.
+
+## Representative bonuses
+
+Each stat also offers representative-specific tuning that is only applied to squad representatives:
+
+| Stat | Ratio entry | Additive entry | Default |
+| ---- | ----------- | -------------- | ------- |
+| Health | `Elite Representative Health Ratio` | `Elite Representative Health Bonus` | `1.0` / `0.0` |
+| Damage reduction | `Elite Representative Damage Reduction Ratio` | `Elite Representative Damage Reduction Bonus` | `1.0` / `0.0` |
+| Resistances | `Elite Representative Resistance Ratio` | `Elite Representative Resistance Bonus` | `1.0` / `0.0` |
+| Power | `Elite Representative Power Ratio` | `Elite Representative Power Bonus` | `1.0` / `0.0` |
+| Attack speed | `Elite Representative Attack Speed Ratio` | `Elite Representative Attack Speed Bonus` | `1.0` / `0.0` |
+| Spell speed | `Elite Representative Spell Speed Ratio` | `Elite Representative Spell Speed Bonus` | `1.0` / `0.0` |
+| Move speed | `Elite Representative Move Speed Ratio` | `Elite Representative Move Speed Bonus` | `1.0` / `0.0` |
+| Knockback resistance | `Elite Representative Knockback Resistance Ratio` | `Elite Representative Knockback Resistance Bonus` | `1.0` / `0.0` |
+
+The representative multiplier is calculated as:
+
+```
+finalMultiplier = squadMultiplier * representativeRatio + representativeBonus
+```
+
+This happens only when elite ambushes are enabled. Non-representative squad members continue to use the squad multiplier alone.


### PR DESCRIPTION
## Summary
- add additive representative configuration entries for elite ambush stat tuning while keeping existing squad multipliers intact
- update the ambush multiplier resolution to always apply squad bonuses and layer representative-specific ratios/additives
- document the new configuration knobs for elite ambush squads

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f91214ead48327a1ff5f90ac53e5f1