### PR TITLE
Add ambush visual buff toggle and randomize selection

### DIFF
--- a/VeinWares.SubtleByte/Config/FactionInfamyConfig.cs
+++ b/VeinWares.SubtleByte/Config/FactionInfamyConfig.cs
@@ -17,6 +17,7 @@ internal static class FactionInfamyConfig
     private static ConfigEntry<int> _maximumHate;
     private static ConfigEntry<int> _autosaveMinutes;
     private static ConfigEntry<int> _autosaveBackups;
+    private static ConfigEntry<bool> _enableAmbushVisualBuffs;
     private static ConfigEntry<bool> _enableHalloweenAmbush;
     private static ConfigEntry<int> _halloweenScarecrowMinimum;
     private static ConfigEntry<int> _halloweenScarecrowMaximum;
@@ -129,6 +130,12 @@ internal static class FactionInfamyConfig
             "Autosave Backups",
             3,
             "Number of rolling backup files to keep whenever the Faction Infamy system saves the hate database.");
+
+        _enableAmbushVisualBuffs = configFile.Bind(
+            "Faction Infamy",
+            "Enable Ambush Visual Buffs",
+            true,
+            "When true, ambush squads can apply randomised visual buffs to spawned units.");
 
         _enableHalloweenAmbush = configFile.Bind(
             "Faction Infamy",
@@ -392,6 +399,7 @@ internal static class FactionInfamyConfig
             Math.Max(1, _maximumHate.Value),
             TimeSpan.FromMinutes(Math.Max(1, _autosaveMinutes.Value)),
             Math.Clamp(_autosaveBackups.Value, 0, 20),
+            _enableAmbushVisualBuffs.Value,
             _enableHalloweenAmbush.Value,
             scarecrowMin,
             scarecrowMax,
@@ -669,6 +677,7 @@ internal readonly record struct FactionInfamyConfigSnapshot(
     int MaximumHate,
     TimeSpan AutosaveInterval,
     int AutosaveBackupCount,
+    bool EnableAmbushVisualBuffs,
     bool EnableHalloweenAmbush,
     int HalloweenScarecrowMinimum,
     int HalloweenScarecrowMaximum,

--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamySystem.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamySystem.cs
@@ -24,6 +24,7 @@ internal static class FactionInfamySystem
     private static int _ambushChancePercent;
     private static float _minimumAmbushHate;
     private static float _maximumHate;
+    private static bool _enableAmbushVisualBuffs;
     private static bool _enableHalloweenAmbush;
     private static int _halloweenScarecrowMinimum;
     private static int _halloweenScarecrowMaximum;
@@ -70,6 +71,8 @@ internal static class FactionInfamySystem
     internal static TimeSpan AmbushCooldown => _ambushCooldown;
 
     internal static float MaximumHate => _maximumHate;
+
+    internal static bool AmbushVisualBuffsEnabled => _enableAmbushVisualBuffs;
 
     internal static bool HalloweenAmbushEnabled => _enableHalloweenAmbush;
 
@@ -157,6 +160,7 @@ internal static class FactionInfamySystem
         _ambushLifetime = config.AmbushLifetime;
         _minimumAmbushHate = config.MinimumAmbushHate;
         _maximumHate = config.MaximumHate;
+        _enableAmbushVisualBuffs = config.EnableAmbushVisualBuffs;
         _enableHalloweenAmbush = config.EnableHalloweenAmbush;
         _halloweenScarecrowMinimum = config.HalloweenScarecrowMinimum;
         _halloweenScarecrowMaximum = config.HalloweenScarecrowMaximum;


### PR DESCRIPTION
## Summary
- add a configuration toggle that controls whether ambush visual buffs are applied and flow it through the Faction Infamy system
- replace the single buff mapping with faction-specific pools and a fallback so visual buffs can be rolled randomly
- apply a shared random buff to the core ambush squad while letting seasonal units (including follow-ups) roll per-unit visuals

## Testing
- `dotnet build VeinWares.SubtleByte/VeinWares.SubtleByte.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68f9220ccfc883278e9c6e6bda0c2fcb