### PR TITLE
Add charm suppression option for ambush spawns

### DIFF
--- a/VeinWares.SubtleByte/Config/FactionInfamyConfig.cs
+++ b/VeinWares.SubtleByte/Config/FactionInfamyConfig.cs
@@ -20,6 +20,7 @@ internal static class FactionInfamyConfig
     private static ConfigEntry<bool> _enableAmbushVisualBuffs;
     private static ConfigEntry<bool> _enableHalloweenAmbush;
     private static ConfigEntry<bool> _disableBloodConsumeOnSpawn;
+    private static ConfigEntry<bool> _disableCharmOnSpawn;
     private static ConfigEntry<int> _halloweenScarecrowMinimum;
     private static ConfigEntry<int> _halloweenScarecrowMaximum;
     private static ConfigEntry<int> _halloweenScarecrowRareMultiplier;
@@ -149,6 +150,12 @@ internal static class FactionInfamyConfig
             "DisableBloodConsumeOnSpawn",
             false,
             "When enabled, ambush spawns strip blood consume and feed components so they cannot be fed upon immediately.");
+
+        _disableCharmOnSpawn = configFile.Bind(
+            "Faction Infamy",
+            "DisableCharmOnSpawn",
+            false,
+            "When enabled, ambush spawns strip charm-related components so they cannot be charmed immediately after spawning.");
 
         _halloweenScarecrowMinimum = configFile.Bind(
             "Faction Infamy",
@@ -409,6 +416,7 @@ internal static class FactionInfamyConfig
             _enableAmbushVisualBuffs.Value,
             _enableHalloweenAmbush.Value,
             _disableBloodConsumeOnSpawn.Value,
+            _disableCharmOnSpawn.Value,
             scarecrowMin,
             scarecrowMax,
             Math.Max(1, _halloweenScarecrowRareMultiplier.Value),
@@ -688,6 +696,7 @@ internal readonly record struct FactionInfamyConfigSnapshot(
     bool EnableAmbushVisualBuffs,
     bool EnableHalloweenAmbush,
     bool DisableBloodConsumeOnSpawn,
+    bool DisableCharmOnSpawn,
     int HalloweenScarecrowMinimum,
     int HalloweenScarecrowMaximum,
     int HalloweenScarecrowRareMultiplier,

--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyAmbushService.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyAmbushService.cs
@@ -816,11 +816,15 @@ internal static class FactionInfamyAmbushService
 
         EnsureFactionAlignment(entityManager, entity, pending);
 
-        if (FactionInfamySystem.SuppressBloodConsumeOnSpawn)
+        var suppressFeed = FactionInfamySystem.SuppressBloodConsumeOnSpawn;
+        var suppressCharm = FactionInfamySystem.SuppressCharmOnSpawn;
+        if (suppressFeed || suppressCharm)
         {
-            SpawnFeedSuppressionService.SuppressFeedingComponents(
+            SpawnSuppressionService.SuppressSpawnComponents(
                 entityManager,
                 entity,
+                suppressFeed,
+                suppressCharm,
                 $"ambush faction '{pending.FactionId}'");
         }
 

--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamySystem.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamySystem.cs
@@ -27,6 +27,7 @@ internal static class FactionInfamySystem
     private static bool _enableAmbushVisualBuffs;
     private static bool _enableHalloweenAmbush;
     private static bool _disableBloodConsumeOnSpawn;
+    private static bool _disableCharmOnSpawn;
     private static int _halloweenScarecrowMinimum;
     private static int _halloweenScarecrowMaximum;
     private static int _halloweenScarecrowRareMultiplier;
@@ -78,6 +79,8 @@ internal static class FactionInfamySystem
     internal static bool HalloweenAmbushEnabled => _enableHalloweenAmbush;
 
     internal static bool SuppressBloodConsumeOnSpawn => _disableBloodConsumeOnSpawn;
+
+    internal static bool SuppressCharmOnSpawn => _disableCharmOnSpawn;
 
     internal static int HalloweenScarecrowMinimum => _halloweenScarecrowMinimum;
 
@@ -166,6 +169,7 @@ internal static class FactionInfamySystem
         _enableAmbushVisualBuffs = config.EnableAmbushVisualBuffs;
         _enableHalloweenAmbush = config.EnableHalloweenAmbush;
         _disableBloodConsumeOnSpawn = config.DisableBloodConsumeOnSpawn;
+        _disableCharmOnSpawn = config.DisableCharmOnSpawn;
         _halloweenScarecrowMinimum = config.HalloweenScarecrowMinimum;
         _halloweenScarecrowMaximum = config.HalloweenScarecrowMaximum;
         _halloweenScarecrowRareMultiplier = config.HalloweenScarecrowRareMultiplier;

--- a/VeinWares.SubtleByte/Services/SpawnSuppressionService.cs
+++ b/VeinWares.SubtleByte/Services/SpawnSuppressionService.cs
@@ -3,13 +3,14 @@ using System.Collections.Generic;
 using System.Linq;
 using Il2CppInterop.Runtime;
 using ProjectM;
+using Unity.Collections;
 using Unity.Entities;
 using VeinWares.SubtleByte.Extensions;
 using VeinWares.SubtleByte.Utilities;
 
 namespace VeinWares.SubtleByte.Services;
 
-internal static class SpawnFeedSuppressionService
+internal static class SpawnSuppressionService
 {
     private static readonly string[] AdditionalFeedComponentTypeNames =
     {
@@ -24,15 +25,42 @@ internal static class SpawnFeedSuppressionService
 
     private static readonly IReadOnlyList<ComponentRemovalTarget> AdditionalFeedComponentTypes = ResolveAdditionalFeedComponentTypes();
 
-    public static bool SuppressFeedingComponents(EntityManager entityManager, Entity entity, string? context = null)
+    public static bool SuppressSpawnComponents(
+        EntityManager entityManager,
+        Entity entity,
+        bool suppressFeed,
+        bool suppressCharm,
+        string? context = null)
     {
-        if (!entity.Exists())
+        if (!entity.Exists() || (!suppressFeed && !suppressCharm))
         {
             return false;
         }
 
         var removedComponents = new List<string>();
 
+        if (suppressFeed)
+        {
+            SuppressFeedComponents(entityManager, entity, removedComponents);
+        }
+
+        if (suppressCharm)
+        {
+            SuppressCharmComponents(entityManager, entity, removedComponents);
+        }
+
+        if (removedComponents.Count == 0)
+        {
+            return false;
+        }
+
+        var contextSuffix = string.IsNullOrWhiteSpace(context) ? string.Empty : $" ({context})";
+        ModLogger.Info($"[Spawn] Removed components [{string.Join(", ", removedComponents)}] from entity {entity.Index}{contextSuffix}.");
+        return true;
+    }
+
+    private static void SuppressFeedComponents(EntityManager entityManager, Entity entity, List<string> removedComponents)
+    {
         if (entity.Has<BloodConsumeSource>())
         {
             entity.Remove<BloodConsumeSource>();
@@ -55,15 +83,59 @@ internal static class SpawnFeedSuppressionService
             entityManager.RemoveComponent(entity, component.ComponentType);
             removedComponents.Add(component.DisplayName);
         }
+    }
 
-        if (removedComponents.Count == 0)
+    private static void SuppressCharmComponents(EntityManager entityManager, Entity entity, List<string> removedComponents)
+    {
+        using var componentTypes = entityManager.GetComponentTypes(entity);
+        if (!componentTypes.IsCreated || componentTypes.Length == 0)
+        {
+            return;
+        }
+
+        var toRemove = new List<ComponentType>();
+
+        for (var i = 0; i < componentTypes.Length; i++)
+        {
+            var componentType = componentTypes[i];
+            var managedType = TypeManager.GetType(componentType.TypeIndex);
+            if (managedType == null)
+            {
+                continue;
+            }
+
+            if (!IsCharmRelated(managedType))
+            {
+                continue;
+            }
+
+            toRemove.Add(componentType);
+            removedComponents.Add(managedType.Name);
+        }
+
+        foreach (var componentType in toRemove)
+        {
+            if (entityManager.HasComponent(entity, componentType))
+            {
+                entityManager.RemoveComponent(entity, componentType);
+            }
+        }
+    }
+
+    private static bool IsCharmRelated(Type managedType)
+    {
+        var fullName = managedType.FullName ?? managedType.Name;
+        if (string.IsNullOrEmpty(fullName))
         {
             return false;
         }
 
-        var contextSuffix = string.IsNullOrWhiteSpace(context) ? string.Empty : $" ({context})";
-        ModLogger.Info($"[Spawn] Removed feed components [{string.Join(", ", removedComponents)}] from entity {entity.Index}{contextSuffix}.");
-        return true;
+        if (fullName.IndexOf("Charm", StringComparison.OrdinalIgnoreCase) < 0)
+        {
+            return false;
+        }
+
+        return fullName.Contains("ProjectM.", StringComparison.Ordinal);
     }
 
     private static IReadOnlyList<ComponentRemovalTarget> ResolveAdditionalFeedComponentTypes()

--- a/docs/faction-infamy-config.md
+++ b/docs/faction-infamy-config.md
@@ -10,6 +10,7 @@ below highlights the core values that server operators tend to tune most often.
 | `Minimum Ambush Hate` | `50.0` | Minimum post-multiplier hate required before an ambush squad can spawn against a player. |
 | `Ambush Chance Percent` | `50` | Roll that determines whether an eligible combat encounter actually spawns an ambush squad. |
 | `DisableBloodConsumeOnSpawn` | `false` | When set to `true`, freshly spawned ambush units have their blood consume and feeding components removed so they cannot be fed upon immediately. |
+| `DisableCharmOnSpawn` | `false` | When enabled, ambush squads remove charm sources and related debuffs so newly spawned enemies cannot be charmed right away. |
 
 Additional seasonal, elite, and visual buff options are available in the same section for
 fine-grained control of late-game ambushes.


### PR DESCRIPTION
## Summary
- add a DisableCharmOnSpawn toggle to the faction infamy configuration and snapshot
- extend the spawn suppression helper to drop both feeding and charm-related components when configured
- wire the new suppression into ambush spawns and document the charm immunity option

## Testing
- ⚠️ `dotnet build VeinWares.SubtleByte/VeinWares.SubtleByte.csproj` *(dotnet is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68fa85fd06a8832786ca5ba38e224999