### PR TITLE
Fix charm suppression component lookup

### DIFF
--- a/VeinWares.SubtleByte/Services/SpawnSuppressionService.cs
+++ b/VeinWares.SubtleByte/Services/SpawnSuppressionService.cs
@@ -100,8 +100,7 @@ internal static class SpawnSuppressionService
             for (var i = 0; i < componentTypes.Length; i++)
             {
                 var componentType = componentTypes[i];
-                var typeInfo = TypeManager.GetTypeInfo(componentType.TypeIndex);
-                var managedTypeName = typeInfo.DebugTypeName.ToString();
+                var managedTypeName = componentType.ToString();
 
                 if (string.IsNullOrEmpty(managedTypeName))
                 {


### PR DESCRIPTION
## Summary
- avoid using TypeManager.DebugTypeName when collecting charm-related components
- rely on ComponentType.ToString() to identify components safely during suppression

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb3a96e14483278623960ec7cb91a2