### PR TITLE
Disable feeding by flagging blood source instead of removal

### DIFF
--- a/VeinWares.SubtleByte/Services/SpawnSuppressionService.cs
+++ b/VeinWares.SubtleByte/Services/SpawnSuppressionService.cs
@@ -23,7 +23,16 @@ internal static class SpawnSuppressionService
         "ProjectM.Feedable",
     };
 
-    private static readonly IReadOnlyList<ComponentRemovalTarget> AdditionalFeedComponentTypes = ResolveAdditionalFeedComponentTypes();
+    private static readonly IReadOnlyList<ComponentRemovalTarget> AdditionalFeedComponentTypes =
+        ResolveComponentTypes(AdditionalFeedComponentTypeNames);
+
+    private static readonly string[] CharmComponentTypeNames =
+    {
+        "ProjectM.CharmSource",
+    };
+
+    private static readonly IReadOnlyList<ComponentRemovalTarget> CharmComponentTypes =
+        ResolveComponentTypes(CharmComponentTypeNames);
 
     public static bool SuppressSpawnComponents(
         EntityManager entityManager,
@@ -61,16 +70,14 @@ internal static class SpawnSuppressionService
 
     private static void SuppressFeedComponents(EntityManager entityManager, Entity entity, List<string> removedComponents)
     {
-        if (entity.Has<BloodConsumeSource>())
-        {
-            entity.Remove<BloodConsumeSource>();
-            removedComponents.Add(nameof(BloodConsumeSource));
-        }
+        var suppressedQuality = ApplyBloodConsumeSourceSuppression(entityManager, entity, removedComponents);
+        var removedAny = false;
 
         if (entity.Has<FeedableInventory>())
         {
             entity.Remove<FeedableInventory>();
             removedComponents.Add(nameof(FeedableInventory));
+            removedAny = true;
         }
 
         foreach (var component in AdditionalFeedComponentTypes)
@@ -82,11 +89,79 @@ internal static class SpawnSuppressionService
 
             entityManager.RemoveComponent(entity, component.ComponentType);
             removedComponents.Add(component.DisplayName);
+            removedAny = true;
         }
+
+        if (!suppressedQuality.HasValue && removedAny)
+        {
+            var fallbackQuality = CalculateSuppressedBloodQuality(ReadSpawnBloodQuality(entityManager, entity));
+            if (TrySetSpawnBloodQuality(entityManager, entity, fallbackQuality))
+            {
+                removedComponents.Add($"{nameof(UnitSpawnData)}.{nameof(UnitSpawnData.BloodQuality)}={(int)MathF.Round(fallbackQuality)}");
+            }
+        }
+    }
+
+    private static float? ApplyBloodConsumeSourceSuppression(EntityManager entityManager, Entity entity, List<string> removedComponents)
+    {
+        if (!entityManager.TryGetComponentData(entity, out BloodConsumeSource bloodConsumeSource))
+        {
+            return null;
+        }
+
+        var sourceQuality = DetermineBloodQualitySource(entityManager, entity, bloodConsumeSource);
+        var suppressedQuality = CalculateSuppressedBloodQuality(sourceQuality);
+        var changed = false;
+
+        if (bloodConsumeSource.CanBeConsumed)
+        {
+            bloodConsumeSource.CanBeConsumed = false;
+            removedComponents.Add($"{nameof(BloodConsumeSource)}.{nameof(BloodConsumeSource.CanBeConsumed)}=false");
+            changed = true;
+        }
+
+        if (!Approximately(bloodConsumeSource.BloodQuality, suppressedQuality))
+        {
+            bloodConsumeSource.BloodQuality = suppressedQuality;
+            removedComponents.Add($"{nameof(BloodConsumeSource)}.{nameof(BloodConsumeSource.BloodQuality)}={(int)MathF.Round(suppressedQuality)}");
+            changed = true;
+        }
+
+        if (changed)
+        {
+            entityManager.SetComponentData(entity, bloodConsumeSource);
+        }
+
+        if (TrySetSpawnBloodQuality(entityManager, entity, suppressedQuality))
+        {
+            removedComponents.Add($"{nameof(UnitSpawnData)}.{nameof(UnitSpawnData.BloodQuality)}={(int)MathF.Round(suppressedQuality)}");
+        }
+
+        return suppressedQuality;
+    }
+
+    private static float DetermineBloodQualitySource(EntityManager entityManager, Entity entity, in BloodConsumeSource bloodConsumeSource)
+    {
+        if (entityManager.TryGetComponentData(entity, out UnitSpawnData spawnData) && spawnData.BloodQuality >= 0f)
+        {
+            return spawnData.BloodQuality;
+        }
+
+        if (bloodConsumeSource.BloodQuality >= 0f)
+        {
+            return bloodConsumeSource.BloodQuality;
+        }
+
+        return 0f;
     }
 
     private static void SuppressCharmComponents(EntityManager entityManager, Entity entity, List<string> removedComponents)
     {
+        if (RemoveKnownCharmComponents(entityManager, entity, removedComponents))
+        {
+            return;
+        }
+
         var componentTypes = entityManager.GetComponentTypes(entity);
         if (!componentTypes.IsCreated || componentTypes.Length == 0)
         {
@@ -130,6 +205,25 @@ internal static class SpawnSuppressionService
         }
     }
 
+    private static bool RemoveKnownCharmComponents(EntityManager entityManager, Entity entity, List<string> removedComponents)
+    {
+        var removedAny = false;
+
+        foreach (var component in CharmComponentTypes)
+        {
+            if (!entityManager.HasComponent(entity, component.ComponentType))
+            {
+                continue;
+            }
+
+            entityManager.RemoveComponent(entity, component.ComponentType);
+            removedComponents.Add(component.DisplayName);
+            removedAny = true;
+        }
+
+        return removedAny;
+    }
+
     private static bool IsCharmRelated(string managedTypeName)
     {
         if (string.IsNullOrEmpty(managedTypeName))
@@ -145,9 +239,50 @@ internal static class SpawnSuppressionService
         return managedTypeName.Contains("ProjectM.", StringComparison.Ordinal);
     }
 
-    private static IReadOnlyList<ComponentRemovalTarget> ResolveAdditionalFeedComponentTypes()
+    private static bool TrySetSpawnBloodQuality(EntityManager entityManager, Entity entity, float suppressedQuality)
     {
-        return AdditionalFeedComponentTypeNames
+        if (!entityManager.TryGetComponentData(entity, out UnitSpawnData spawnData))
+        {
+            return false;
+        }
+
+        if (Approximately(spawnData.BloodQuality, suppressedQuality))
+        {
+            return false;
+        }
+
+        spawnData.BloodQuality = suppressedQuality;
+        entityManager.SetComponentData(entity, spawnData);
+        return true;
+    }
+
+    private static float ReadSpawnBloodQuality(EntityManager entityManager, Entity entity)
+    {
+        if (entityManager.TryGetComponentData(entity, out UnitSpawnData spawnData) && spawnData.BloodQuality >= 0f)
+        {
+            return spawnData.BloodQuality;
+        }
+
+        return 0f;
+    }
+
+    private static float CalculateSuppressedBloodQuality(float currentQuality)
+    {
+        var sanitizedQuality = MathF.Clamp(currentQuality, 0f, 99f);
+        var tier = (int)(sanitizedQuality / 20f);
+        var baseQuality = tier * 20f;
+        var offsetQuality = Math.Min(baseQuality + 5f, 95f);
+        return offsetQuality;
+    }
+
+    private static bool Approximately(float left, float right)
+    {
+        return Math.Abs(left - right) <= 0.001f;
+    }
+
+    private static IReadOnlyList<ComponentRemovalTarget> ResolveComponentTypes(IEnumerable<string> typeNames)
+    {
+        return typeNames
             .Select(FindComponentType)
             .Where(component => component.HasValue)
             .Select(component => component!.Value)


### PR DESCRIPTION
## Summary
- keep spawned units' blood consume source component but mark it non-consumable and clamp quality into five offset tiers to prevent -1 displays
- update spawn data blood quality when suppressing feed components so units retain consistent, non-100% values

## Testing
- `dotnet build VeinWares.SubtleByte/VeinWares.SubtleByte.csproj` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fb53f1edf88327b6a5aa5be03bf284