### PR TITLE
Remove duplicate blood suppression helpers

### DIFF
--- a/VeinWares.SubtleByte/Services/SpawnSuppressionService.cs
+++ b/VeinWares.SubtleByte/Services/SpawnSuppressionService.cs
@@ -155,59 +155,6 @@ internal static class SpawnSuppressionService
         return 0f;
     }
 
-    private static float? ApplyBloodConsumeSourceSuppression(EntityManager entityManager, Entity entity, List<string> removedComponents)
-    {
-        if (!entityManager.TryGetComponentData(entity, out BloodConsumeSource bloodConsumeSource))
-        {
-            return null;
-        }
-
-        var sourceQuality = DetermineBloodQualitySource(entityManager, entity, bloodConsumeSource);
-        var suppressedQuality = CalculateSuppressedBloodQuality(sourceQuality);
-        var changed = false;
-
-        if (bloodConsumeSource.CanBeConsumed)
-        {
-            bloodConsumeSource.CanBeConsumed = false;
-            removedComponents.Add($"{nameof(BloodConsumeSource)}.{nameof(BloodConsumeSource.CanBeConsumed)}=false");
-            changed = true;
-        }
-
-        if (!Approximately(bloodConsumeSource.BloodQuality, suppressedQuality))
-        {
-            bloodConsumeSource.BloodQuality = suppressedQuality;
-            removedComponents.Add($"{nameof(BloodConsumeSource)}.{nameof(BloodConsumeSource.BloodQuality)}={(int)MathF.Round(suppressedQuality)}");
-            changed = true;
-        }
-
-        if (changed)
-        {
-            entityManager.SetComponentData(entity, bloodConsumeSource);
-        }
-
-        if (TrySetSpawnBloodQuality(entityManager, entity, suppressedQuality))
-        {
-            removedComponents.Add($"{nameof(UnitSpawnData)}.{nameof(UnitSpawnData.BloodQuality)}={(int)MathF.Round(suppressedQuality)}");
-        }
-
-        return suppressedQuality;
-    }
-
-    private static float DetermineBloodQualitySource(EntityManager entityManager, Entity entity, in BloodConsumeSource bloodConsumeSource)
-    {
-        if (entityManager.TryGetComponentData(entity, out UnitSpawnData spawnData) && spawnData.BloodQuality >= 0f)
-        {
-            return spawnData.BloodQuality;
-        }
-
-        if (bloodConsumeSource.BloodQuality >= 0f)
-        {
-            return bloodConsumeSource.BloodQuality;
-        }
-
-        return 0f;
-    }
-
     private static void SuppressCharmComponents(EntityManager entityManager, Entity entity, List<string> removedComponents)
     {
         if (RemoveKnownCharmComponents(entityManager, entity, removedComponents))


### PR DESCRIPTION
## Summary
- remove duplicate definitions of ApplyBloodConsumeSourceSuppression and DetermineBloodQualitySource
- resolve ambiguous call and member redefinition compiler errors in SpawnSuppressionService

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fb5d690294832798e4412053a9939d