### PR TITLE
Fix territory bounds comparison for guard ambush detection

### DIFF
--- a/VeinWares.SubtleByte/Utilities/TerritoryUtility.cs
+++ b/VeinWares.SubtleByte/Utilities/TerritoryUtility.cs
@@ -113,7 +113,7 @@ internal static class TerritoryUtility
         var x = position.x;
         var z = position.z;
 
-        return x >= min.x && x <= max.x && z >= min.y && z <= max.y;
+        return x >= min.x && x <= max.x && z >= min.z && z <= max.z;
     }
 
     private static bool TryExists(EntityManager entityManager, Entity entity)


### PR DESCRIPTION
## Summary
- ensure castle territory containment checks compare the Z coordinate against the territory's Z bounds

## Testing
- not run (dotnet CLI unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68fb7e4e676c8327928671d973b6e15d