### PR TITLE
Fix territory bounds check to use Z axis

### DIFF
--- a/VeinWares.SubtleByte/Utilities/TerritoryUtility.cs
+++ b/VeinWares.SubtleByte/Utilities/TerritoryUtility.cs
@@ -112,7 +112,7 @@ internal static class TerritoryUtility
         var x = position.x;
         var z = position.z;
 
-        return x >= min.x && x <= max.x && z >= min.y && z <= max.y;
+        return x >= min.x && x <= max.x && z >= min.z && z <= max.z;
     }
 
     private static bool TryExists(EntityManager entityManager, Entity entity)


### PR DESCRIPTION
## Summary
- correct the territory bounds check to use the Z-axis range when evaluating player positions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb80703ad08327b88341a1f5873d33