### PR TITLE
Fix delegate binding for territory helper reflection

### DIFF
--- a/VeinWares.SubtleByte/Utilities/NativeCastleTerritoryHelper.cs
+++ b/VeinWares.SubtleByte/Utilities/NativeCastleTerritoryHelper.cs
@@ -108,7 +108,7 @@ internal static class NativeCastleTerritoryHelper
     }
 
     private static void TryBind<T>(MethodInfo method, ref T? target)
-        where T : class
+        where T : Delegate
     {
         if (target is not null)
         {


### PR DESCRIPTION
## Summary
- constrain the reflection binding helper to delegate types so CreateDelegate casts safely

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68fb92494748832797b3055e60aebcbf