### PR TITLE
Fix ambush territory protection check

### DIFF
--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyAmbushService.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyAmbushService.cs
@@ -319,7 +319,7 @@ internal static class FactionInfamyAmbushService
         }
 
         if (FactionInfamySystem.AmbushTerritoryProtectionEnabled
-            && TerritoryUtility.IsInsidePlayerTerritory(entityManager, playerEntity, position, out var territoryIndex))
+            && TerritoryUtility.IsInsidePlayerTerritory(entityManager, playerEntity, steamId, position, out var territoryIndex))
         {
             _log?.LogDebug($"[Infamy] Blocked ambush for {steamId} inside owned territory (territory index {territoryIndex}).");
             return;

--- a/VeinWares.SubtleByte/Utilities/TerritoryUtility.cs
+++ b/VeinWares.SubtleByte/Utilities/TerritoryUtility.cs
@@ -10,7 +10,12 @@ namespace VeinWares.SubtleByte.Utilities;
 
 internal static class TerritoryUtility
 {
-    public static bool IsInsidePlayerTerritory(EntityManager entityManager, Entity playerEntity, float3 position, out int territoryIndex)
+    public static bool IsInsidePlayerTerritory(
+        EntityManager entityManager,
+        Entity playerEntity,
+        ulong steamId,
+        float3 position,
+        out int territoryIndex)
     {
         territoryIndex = -1;
 
@@ -85,22 +90,27 @@ internal static class TerritoryUtility
                     sameTeam = true;
                 }
 
-                if (!sameTeam && userEntity != Entity.Null
-                    && entityManager.TryGetComponentData(heartEntity, out UserOwner userOwner))
+                if (!sameTeam && entityManager.TryGetComponentData(heartEntity, out UserOwner userOwner))
                 {
                     var ownerUserEntity = userOwner.Owner.GetEntityOnServer();
                     if (ownerUserEntity != Entity.Null && TryExists(entityManager, ownerUserEntity))
                     {
-                        if (ownerUserEntity == userEntity)
+                        if (userEntity != Entity.Null && ownerUserEntity == userEntity)
                         {
                             sameTeam = true;
                         }
-                        else if (hasClan
-                            && entityManager.TryGetComponentData(ownerUserEntity, out User ownerUser)
-                            && !ownerUser.ClanEntity.Equals(NetworkedEntity.Empty)
-                            && ownerUser.ClanEntity.Equals(clanEntity))
+                        else if (entityManager.TryGetComponentData(ownerUserEntity, out User ownerUser))
                         {
-                            sameTeam = true;
+                            if (steamId != 0UL && ownerUser.PlatformId == steamId)
+                            {
+                                sameTeam = true;
+                            }
+                            else if (hasClan
+                                && !ownerUser.ClanEntity.Equals(NetworkedEntity.Empty)
+                                && ownerUser.ClanEntity.Equals(clanEntity))
+                            {
+                                sameTeam = true;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- pass the player's steam ID to the ambush territory check so we can match by ownership
- expand the territory utility to treat matching platform IDs as the same owner, preserving clan checks

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68fb960b83408327a26cb8ba2546ab2d