### PR TITLE
Gate ambush visual buffs behind elite squads

### DIFF
--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamySystem.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamySystem.cs
@@ -78,7 +78,12 @@ internal static class FactionInfamySystem
 
     internal static float MaximumHate => _maximumHate;
 
-    internal static bool AmbushVisualBuffsEnabled => _enableAmbushVisualBuffs;
+    internal static bool AmbushVisualBuffsEnabled => _enableEliteAmbush && _enableAmbushVisualBuffs;
+
+    internal static bool ShouldApplyAmbushVisualBuffs(bool isElite)
+    {
+        return AmbushVisualBuffsEnabled && isElite;
+    }
 
     internal static bool HalloweenAmbushEnabled => _enableHalloweenAmbush;
 

--- a/docs/faction-infamy-config.md
+++ b/docs/faction-infamy-config.md
@@ -14,3 +14,10 @@ below highlights the core values that server operators tend to tune most often.
 
 Additional seasonal, elite, and visual buff options are available in the same section for
 fine-grained control of late-game ambushes.
+
+## Elite ambush visuals
+
+`EnableEliteAmbush` must stay enabled for any elite-only functionality, including the
+`EnableAmbushVisualBuffs` toggle. When both options are true, elite ambush squads gain the
+distinct "elite" visual effects while regular ambushes remain unchanged. Disabling either
+setting prevents the additional visuals from appearing.


### PR DESCRIPTION
## Summary
- stop applying ambush visual effects to non-elite ambush squads by propagating their elite status
- gate the visual effect behind both the elite ambush and visual buff configuration toggles
- document how the elite ambush and visual buff settings interact in the configuration guide

## Testing
- dotnet build VeinWares.SubtleByte.sln *(fails: `dotnet` is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68fb986998b48327bfca6bad4959b6ad