### PR TITLE
Restore TradersT02 base hate override in ambush data

### DIFF
--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyAmbushData.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyAmbushData.cs
@@ -762,6 +762,10 @@ internal static class FactionInfamyAmbushData
           \"hate\": 25
         },
         {
+          \"factionGuid\": 887347866,
+          \"hate\": 300
+        },
+        {
           \"factionGuid\": 1094603131,
           \"hate\": 15
         }


### PR DESCRIPTION
## Summary
- reinstate the militia base hate override for TradersT02 (887347866) so tier-2 traders retain their legacy infamy penalty

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68fba01e169c83279e6467e3698f21f2