### PR TITLE
Fix combat state initialization for new hate gains

### DIFF
--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamySystem.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamySystem.cs
@@ -427,10 +427,7 @@ internal static class FactionInfamySystem
             return;
         }
 
-        if (!PlayerHate.TryGetValue(steamId, out var data))
-        {
-            return;
-        }
+        var data = PlayerHate.GetOrAdd(steamId, static _ => new PlayerHateData());
 
         var now = DateTime.UtcNow;
 


### PR DESCRIPTION
## Summary
- ensure RegisterCombatStart creates a PlayerHateData entry before updating combat state

## Testing
- dotnet build VeinWares.SubtleByte.sln *(fails: dotnet not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fba5d65a3c83279f5906d5bbbab750