### PR TITLE
Disable performance logging in production plugin

### DIFF
--- a/VeinWares.SubtleByte/Plugin.cs
+++ b/VeinWares.SubtleByte/Plugin.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using BepInEx;
 using BepInEx.Logging;
 using BepInEx.Unity.IL2CPP;
@@ -46,8 +45,7 @@ namespace VeinWares.SubtleByte
             _harmony.PatchAll(System.Reflection.Assembly.GetExecutingAssembly());
             PrestigeLiveSync.Initialize();
 
-            var performanceLogPath = Path.Combine(Paths.ConfigPath, "VeinWares SubtleByte", "performance.log");
-            var performanceTracker = new PerformanceTracker(Log, thresholdMilliseconds: 5.0, performanceLogPath);
+            var performanceTracker = new PerformanceTracker(Log, thresholdMilliseconds: 5.0, isEnabled: false);
             var moduleConfig = new ModuleConfig(
                 SubtleBytePluginConfig.EmptyBottleRefundEnabledEntry,
                 SubtleBytePluginConfig.InfamySystemEnabledEntry);


### PR DESCRIPTION
## Summary
- allow the production performance tracker to be disabled without removing call sites
- stop the production plugin from writing performance logs

## Testing
- dotnet build VeinWares.SubtleByte/VeinWares.SubtleByte.csproj *(fails: `dotnet` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fbc901d598832783a7f65bca75f10c