### PR TITLE
Normalize infamy hate caps and clean up diagnostics

### DIFF
--- a/VeinWares.SubtleByte/Config/Infamy/FactionInfamyConfig.cs
+++ b/VeinWares.SubtleByte/Config/Infamy/FactionInfamyConfig.cs
@@ -116,7 +116,7 @@ internal static class FactionInfamyConfig
             _minimumAmbushHate = Bind(Section.Core, "Minimum Ambush Hate", 50.0f,
                 "Players must reach this hate level (after multipliers) before ambush squads are considered.", LegacySection);
 
-            _maximumHate = Bind(Section.Core, "Maximum Hate", 300,
+            _maximumHate = Bind(Section.Core, "Maximum Hate", 100,
                 "Upper bound for hate per faction. Any calculated hate beyond this value will be clamped.", LegacySection);
 
             _ambushCooldownMinutes = Bind(Section.Ambush, "Ambush Cooldown Minutes", 15.0f,

--- a/VeinWares.SubtleByte/Services/CleanupMarkerService.cs
+++ b/VeinWares.SubtleByte/Services/CleanupMarkerService.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using BepInEx;
+using BepInEx.Logging;
+
+namespace VeinWares.SubtleByte.Services;
+
+internal static class CleanupMarkerService
+{
+    private const string MarkerFileName = "cleanup_done.json";
+
+    private static readonly HashSet<string> WatchedPaths = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly List<FileSystemWatcher> Watchers = new();
+    private static ManualLogSource? _log;
+
+    public static void Initialize(ManualLogSource log)
+    {
+        _log = log ?? throw new ArgumentNullException(nameof(log));
+
+        Shutdown();
+
+        var candidates = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            Paths.ConfigPath,
+            Path.Combine(Paths.ConfigPath, "VeinWares SubtleByte")
+        };
+
+        foreach (var directory in candidates)
+        {
+            if (string.IsNullOrWhiteSpace(directory))
+            {
+                continue;
+            }
+
+            try
+            {
+                Directory.CreateDirectory(directory);
+            }
+            catch (Exception ex)
+            {
+                _log?.LogDebug($"[CleanupGuard] Skipping directory '{directory}' due to error: {ex.Message}");
+                continue;
+            }
+
+            var markerPath = Path.Combine(directory, MarkerFileName);
+            TryDeleteMarker(markerPath);
+            TryWatchDirectory(directory, markerPath);
+        }
+    }
+
+    public static void Shutdown()
+    {
+        foreach (var watcher in Watchers)
+        {
+            try
+            {
+                watcher.EnableRaisingEvents = false;
+                watcher.Created -= OnMarkerChanged;
+                watcher.Changed -= OnMarkerChanged;
+                watcher.Renamed -= OnMarkerRenamed;
+                watcher.Dispose();
+            }
+            catch (Exception ex)
+            {
+                _log?.LogDebug($"[CleanupGuard] Failed to dispose watcher: {ex.Message}");
+            }
+        }
+
+        Watchers.Clear();
+        WatchedPaths.Clear();
+    }
+
+    private static void TryWatchDirectory(string directory, string markerPath)
+    {
+        if (WatchedPaths.Contains(directory))
+        {
+            return;
+        }
+
+        try
+        {
+            var watcher = new FileSystemWatcher(directory, MarkerFileName)
+            {
+                NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.CreationTime,
+                IncludeSubdirectories = false,
+                EnableRaisingEvents = true
+            };
+
+            watcher.Created += OnMarkerChanged;
+            watcher.Changed += OnMarkerChanged;
+            watcher.Renamed += OnMarkerRenamed;
+
+            Watchers.Add(watcher);
+            WatchedPaths.Add(directory);
+
+            // Delete again in case the marker was created between initial delete and watcher creation.
+            TryDeleteMarker(markerPath);
+        }
+        catch (Exception ex)
+        {
+            _log?.LogWarning($"[CleanupGuard] Failed to watch '{directory}' for cleanup markers: {ex.Message}");
+        }
+    }
+
+    private static void OnMarkerChanged(object sender, FileSystemEventArgs e)
+    {
+        if (!string.Equals(Path.GetFileName(e.Name), MarkerFileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        TryDeleteMarker(e.FullPath);
+    }
+
+    private static void OnMarkerRenamed(object sender, RenamedEventArgs e)
+    {
+        if (!string.Equals(Path.GetFileName(e.Name), MarkerFileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        TryDeleteMarker(e.FullPath);
+    }
+
+    private static void TryDeleteMarker(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return;
+        }
+
+        try
+        {
+            if (!File.Exists(path))
+            {
+                return;
+            }
+
+            File.Delete(path);
+            _log?.LogInfo($"[CleanupGuard] Removed unexpected cleanup marker at '{path}'.");
+        }
+        catch (Exception ex)
+        {
+            _log?.LogWarning($"[CleanupGuard] Failed to delete cleanup marker '{path}': {ex.Message}");
+        }
+    }
+}

--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyAmbushData.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyAmbushData.cs
@@ -697,7 +697,7 @@ internal static class FactionInfamyAmbushData
       ""baseHateOverrides"": [
         {
           ""factionGuid"": 30052367,
-          ""hate"": 300
+          ""hate"": 100
         }
       ]
     },

--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyAmbushService.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyAmbushService.cs
@@ -364,6 +364,7 @@ internal static class FactionInfamyAmbushService
                 unit.Prefab,
                 steamId,
                 factionId,
+                difficulty.Tier,
                 targetLevel,
                 count,
                 reliefPerUnit,
@@ -761,7 +762,8 @@ internal static class FactionInfamyAmbushService
                 entity,
                 suppressFeed,
                 suppressCharm,
-                $"ambush faction '{pending.FactionId}'");
+                $"ambush faction '{pending.FactionId}'",
+                pending.DifficultyTier);
         }
 
         ActiveAmbushes[entity] = new ActiveAmbush(pending.TargetSteamId, pending.FactionId, pending.HateReliefPerUnit);
@@ -1160,6 +1162,7 @@ internal static class FactionInfamyAmbushService
             PrefabGUID prefab,
             ulong targetSteamId,
             string factionId,
+            int difficultyTier,
             int unitLevel,
             int remaining,
             float hateReliefPerUnit,
@@ -1173,6 +1176,7 @@ internal static class FactionInfamyAmbushService
             Prefab = prefab;
             TargetSteamId = targetSteamId;
             FactionId = factionId;
+            DifficultyTier = difficultyTier;
             UnitLevel = unitLevel;
             Remaining = remaining;
             HateReliefPerUnit = hateReliefPerUnit;
@@ -1189,6 +1193,8 @@ internal static class FactionInfamyAmbushService
         public ulong TargetSteamId { get; }
 
         public string FactionId { get; }
+
+        public int DifficultyTier { get; }
 
         public int UnitLevel { get; }
 
@@ -1296,6 +1302,7 @@ internal static class FactionInfamyAmbushService
                     unit.Prefab,
                     _steamId,
                     _factionId,
+                    _difficulty.Tier,
                     targetLevel,
                     count,
                     _hateReliefPerUnit,


### PR DESCRIPTION
## Summary
- prevent `cleanup_done.json` from lingering by deleting it at startup and watching the config directories
- write performance diagnostics into a dedicated `Performance` subfolder for easier log management
- align faction infamy scaling around a 100 hate ceiling, update trader overrides, clamp persisted data, and drive ambush blood quality directly from the tier

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68fbcb9a7af48327b72e8c1c3e52bda3