### PR TITLE
Enable nullable context and resolve infamy warnings

### DIFF
--- a/VeinWares.SubtleByte/Config/Infamy/FactionInfamyConfig.cs
+++ b/VeinWares.SubtleByte/Config/Infamy/FactionInfamyConfig.cs
@@ -1,6 +1,8 @@
 using System;
 using BepInEx.Configuration;
 
+#nullable enable
+
 namespace VeinWares.SubtleByte.Config;
 
 internal static class FactionInfamyConfig

--- a/VeinWares.SubtleByte/Config/ItemStackConfig.cs
+++ b/VeinWares.SubtleByte/Config/ItemStackConfig.cs
@@ -6,6 +6,8 @@ using System.Text.Json.Serialization;
 using BepInEx;
 using VeinWares.SubtleByte.Utilities;
 
+#nullable enable
+
 namespace VeinWares.SubtleByte.Config
 {
     public static class ItemStackConfig

--- a/VeinWares.SubtleByte/Services/FactionInfamy/AmbushDefinitions.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/AmbushDefinitions.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using ProjectM.Shared;
 using Stunlock.Core;
 
+#nullable enable
+
 namespace VeinWares.SubtleByte.Services.FactionInfamy;
 
 internal readonly struct AmbushUnitDefinition

--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyAmbushData.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyAmbushData.cs
@@ -176,8 +176,10 @@ internal static class FactionInfamyAmbushData
 
     internal static bool TryGetFactionByGuid(int guidHash, out string factionId, out float baseHate)
     {
-        if (_squadSnapshot.AggregatedFactions.TryGetValue(guidHash, out factionId))
+        if (_squadSnapshot.AggregatedFactions.TryGetValue(guidHash, out var foundFactionId)
+            && !string.IsNullOrEmpty(foundFactionId))
         {
+            factionId = foundFactionId;
             baseHate = _squadSnapshot.BaseHateOverrides.TryGetValue(guidHash, out var overrideValue)
                 ? overrideValue
                 : 0f;

--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyPersistence.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyPersistence.cs
@@ -7,6 +7,8 @@ using BepInEx;
 using VeinWares.SubtleByte.Models.FactionInfamy;
 using VeinWares.SubtleByte.Utilities;
 
+#nullable enable
+
 namespace VeinWares.SubtleByte.Services.FactionInfamy;
 
 internal static class FactionInfamyPersistence

--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamySpawnUtility.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamySpawnUtility.cs
@@ -5,6 +5,8 @@ using Stunlock.Core;
 using Unity.Entities;
 using Unity.Mathematics;
 
+#nullable enable
+
 namespace VeinWares.SubtleByte.Services.FactionInfamy;
 
 internal static class FactionInfamySpawnUtility

--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamySystem.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamySystem.cs
@@ -15,7 +15,7 @@ internal static class FactionInfamySystem
 {
     private static readonly ConcurrentDictionary<ulong, PlayerHateData> PlayerHate = new();
     private static ManualLogSource? _log;
-    private static FactionInfamyConfigSnapshot _config;
+    private static FactionInfamyConfigSnapshot _config = null!;
     private static bool _initialized;
     private static bool _dirty;
     private static TimeSpan _combatCooldown;

--- a/VeinWares.SubtleByte/Services/SpawnSuppressionService.cs
+++ b/VeinWares.SubtleByte/Services/SpawnSuppressionService.cs
@@ -8,6 +8,8 @@ using Unity.Entities;
 using VeinWares.SubtleByte.Extensions;
 using VeinWares.SubtleByte.Utilities;
 
+#nullable enable
+
 namespace VeinWares.SubtleByte.Services;
 
 internal static class SpawnSuppressionService

--- a/VeinWares.SubtleByte/Utilities/NativeCastleTerritoryHelper.cs
+++ b/VeinWares.SubtleByte/Utilities/NativeCastleTerritoryHelper.cs
@@ -4,6 +4,8 @@ using ProjectM.CastleBuilding;
 using VeinWares.SubtleByte;
 using Unity.Mathematics;
 
+#nullable enable
+
 namespace VeinWares.SubtleByte.Utilities;
 
 internal static class NativeCastleTerritoryHelper


### PR DESCRIPTION
## Summary
- enable nullable annotations in configuration and service helpers that use nullable members
- initialize faction infamy configuration snapshot and harden dictionary lookups to avoid nullability warnings

## Testing
- not run (dotnet CLI is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68fbd20e45e88327aaa613c280c56a6f