### PR TITLE
Adjust faction hate gain and decay

### DIFF
--- a/VeinWares.SubtleByte/Config/Infamy/FactionInfamyConfig.cs
+++ b/VeinWares.SubtleByte/Config/Infamy/FactionInfamyConfig.cs
@@ -106,7 +106,7 @@ internal static class FactionInfamyConfig
             _hateGainMultiplier = Bind(Section.Core, "Hate Gain Multiplier", 1.0f,
                 "Scales the amount of hate granted per qualifying kill.", LegacySection);
 
-            _hateDecayPerMinute = Bind(Section.Core, "Hate Decay Per Minute", 10.0f,
+            _hateDecayPerMinute = Bind(Section.Core, "Hate Decay Per Minute", 2.0f,
                 "Amount of hate removed from every active faction bucket each minute while the player is eligible for cooldown.", LegacySection);
 
             _cooldownGraceSeconds = Bind(Section.Combat, "Cooldown Grace Seconds", 30.0f,

--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyVictimResolver.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyVictimResolver.cs
@@ -9,7 +9,7 @@ namespace VeinWares.SubtleByte.Services.FactionInfamy;
 
 internal static class FactionInfamyVictimResolver
 {
-    private const float DefaultBaseHate = 10f;
+    private const float DefaultBaseHate = 2f;
     private const float VBloodHateMultiplier = 10f;
 
     public static bool TryGetHateForVictim(Entity victim, out string factionId, out float baseHate)


### PR DESCRIPTION
## Summary
- reduce the default base hate assigned to kills so standard enemies now contribute 2 points and VBlood units grant 20
- lower the default hate decay rate to 2 points per minute to keep ambush pacing aligned with the new gain values

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fbd78f051c83279df92c3cf659e203