### PR TITLE
Ensure faction infamy save file is created

### DIFF
--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyPersistence.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyPersistence.cs
@@ -29,6 +29,7 @@ internal static class FactionInfamyPersistence
             var loadPath = GetLoadPath();
             if (loadPath is null)
             {
+                EnsureSaveFileExists();
                 return new Dictionary<ulong, PlayerHateData>();
             }
 
@@ -162,6 +163,30 @@ internal static class FactionInfamyPersistence
         catch (Exception ex)
         {
             ModLogger.Warn($"[InfamyPersistence] Failed to rotate backups: {ex.Message}");
+        }
+    }
+
+    private static void EnsureSaveFileExists()
+    {
+        try
+        {
+            Directory.CreateDirectory(ConfigDirectory);
+
+            if (File.Exists(SavePath))
+            {
+                return;
+            }
+
+            var emptyPayload = JsonSerializer.Serialize(
+                new Dictionary<string, PlayerHateRecord>(),
+                Options);
+
+            File.WriteAllText(SavePath, emptyPayload);
+            ModLogger.Info("[InfamyPersistence] Created new hate data save file");
+        }
+        catch (Exception ex)
+        {
+            ModLogger.Warn($"[InfamyPersistence] Failed to create hate data save file: {ex.Message}");
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure the faction infamy persistence layer creates an empty save file when no existing data exists
- add logging around initial save file creation failures

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68fbdb9c83a88327860fa08a917317ed