### PR TITLE
Fix module host delta time fallback

### DIFF
--- a/VeinWares.SubtleByte.Rewrite/Runtime/Unity/ModuleHostBehaviour.cs
+++ b/VeinWares.SubtleByte.Rewrite/Runtime/Unity/ModuleHostBehaviour.cs
@@ -9,9 +9,25 @@ public sealed class ModuleHostBehaviour : MonoBehaviour
 {
     internal static Action<float>? TickHandler { get; set; }
 
+    private float _lastUpdateTimestamp;
+
+    private void Awake()
+    {
+        _lastUpdateTimestamp = Time.realtimeSinceStartup;
+    }
+
     private void Update()
     {
-        TickHandler?.Invoke(Time.deltaTime);
+        var now = Time.realtimeSinceStartup;
+        var delta = now - _lastUpdateTimestamp;
+        _lastUpdateTimestamp = now;
+
+        if (delta <= 0f)
+        {
+            delta = Time.deltaTime > 0f ? Time.deltaTime : Time.fixedDeltaTime;
+        }
+
+        TickHandler?.Invoke(delta);
     }
 
     private void OnDestroy()

--- a/VeinWares.SubtleByte/Runtime/Unity/ModuleHostBehaviour.cs
+++ b/VeinWares.SubtleByte/Runtime/Unity/ModuleHostBehaviour.cs
@@ -9,9 +9,25 @@ public sealed class ModuleHostBehaviour : MonoBehaviour
 {
     internal static Action<float>? TickHandler { get; set; }
 
+    private float _lastUpdateTimestamp;
+
+    private void Awake()
+    {
+        _lastUpdateTimestamp = Time.realtimeSinceStartup;
+    }
+
     private void Update()
     {
-        TickHandler?.Invoke(Time.deltaTime);
+        var now = Time.realtimeSinceStartup;
+        var delta = now - _lastUpdateTimestamp;
+        _lastUpdateTimestamp = now;
+
+        if (delta <= 0f)
+        {
+            delta = Time.deltaTime > 0f ? Time.deltaTime : Time.fixedDeltaTime;
+        }
+
+        TickHandler?.Invoke(delta);
     }
 
     private void OnDestroy()


### PR DESCRIPTION
## Summary
- accumulate elapsed time with Time.realtimeSinceStartup so module host ticks even when Time.deltaTime is zero
- mirror the delta time fallback in the rewrite scaffolding

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68fd00a016f48327aaf9850f941ef0fa