### PR TITLE
Add infamy clear-all command

### DIFF
--- a/VeinWares.SubtleByte/Commands/FactionInfamyCommands.cs
+++ b/VeinWares.SubtleByte/Commands/FactionInfamyCommands.cs
@@ -62,6 +62,24 @@ public static class FactionInfamyCommands
         ctx.Reply($"[Infamy] Cleared hate for {displayName}.");
     }
 
+    [Command("infamy clear-all", adminOnly: true, description: "Clear all tracked hate data from the infamy system.")]
+    public static void ClearInfamyForAll(ChatCommandContext ctx)
+    {
+        if (!EnsureEnabled(ctx))
+        {
+            return;
+        }
+
+        var clearedCount = FactionInfamySystem.ClearAllPlayerHate();
+        if (clearedCount == 0)
+        {
+            ctx.Reply("[Infamy] No players currently tracked by the infamy system.");
+            return;
+        }
+
+        ctx.Reply($"[Infamy] Cleared hate for {clearedCount} tracked player{(clearedCount == 1 ? string.Empty : "s")}.");
+    }
+
     [Command("infamy add", adminOnly: true, description: "Grant hate to a player or all tracked players. Accepts Steam ID or 'all'.")]
     public static void AddInfamy(ChatCommandContext ctx, string target, string factionId, float amount)
     {

--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamySystem.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamySystem.cs
@@ -585,6 +585,44 @@ internal static class FactionInfamySystem
         }
     }
 
+    public static int ClearAllPlayerHate()
+    {
+        if (!_initialized || PlayerHate.IsEmpty)
+        {
+            return 0;
+        }
+
+        var keys = PlayerHate.Keys.ToArray();
+        if (keys.Length == 0)
+        {
+            return 0;
+        }
+
+        var clearedIds = new List<ulong>(keys.Length);
+        for (var i = 0; i < keys.Length; i++)
+        {
+            var key = keys[i];
+            if (PlayerHate.TryRemove(key, out _))
+            {
+                clearedIds.Add(key);
+            }
+        }
+
+        if (clearedIds.Count == 0)
+        {
+            return 0;
+        }
+
+        _dirty = true;
+
+        for (var i = 0; i < clearedIds.Count; i++)
+        {
+            FactionInfamyRuntime.NotifyPlayerHateCleared(clearedIds[i]);
+        }
+
+        return clearedIds.Count;
+    }
+
     public static IReadOnlyList<FactionInfamyPlayerSnapshot> GetAllPlayerHate()
     {
         if (!_initialized)


### PR DESCRIPTION
## Summary
- add an admin command to clear all tracked infamy data at once
- implement system support to remove every stored player entry and broadcast clear notifications

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68fd1e4f4830832780b228a9b6677733