### PR TITLE
Rebuild infamy persistence autosave timer

### DIFF
--- a/VeinWares.SubtleByte/Modules/FactionInfamy/FactionInfamyModule.cs
+++ b/VeinWares.SubtleByte/Modules/FactionInfamy/FactionInfamyModule.cs
@@ -9,8 +9,6 @@ internal sealed class FactionInfamyModule : IModule, IUpdateModule
 {
     private bool _enabled;
     private bool _disposed;
-    private Runtime.Scheduling.IntervalScheduler.ScheduledHandle _autosaveHandle;
-    private bool _autosaveRegistered;
 
     public void Initialize(ModuleContext context)
     {
@@ -34,12 +32,6 @@ internal sealed class FactionInfamyModule : IModule, IUpdateModule
         FactionInfamySystem.Initialize(snapshot, context.Log);
         FactionInfamyAmbushService.Initialize(context.Log);
 
-        _autosaveHandle = context.Scheduler.Schedule(
-            snapshot.Persistence.AutosaveInterval,
-            FactionInfamySystem.FlushPersistence,
-            runImmediately: false);
-        _autosaveRegistered = true;
-
         context.Log.LogInfo("[Infamy] Faction Infamy module initialised.");
     }
 
@@ -62,11 +54,6 @@ internal sealed class FactionInfamyModule : IModule, IUpdateModule
         if (_disposed)
         {
             return;
-        }
-
-        if (_autosaveRegistered)
-        {
-            _autosaveHandle.Dispose();
         }
 
         if (_enabled)


### PR DESCRIPTION
## Summary
- remove the standalone persistence scheduler and fold dirty tracking back into the faction infamy system
- drive autosave timing directly from the system tick with an internal accumulator that flushes and resets when dirty data ages past the configured interval
- simplify the faction infamy module initialization and disposal flow to match the new initialize signature and explicitly flush before shutdown

## Testing
- `dotnet build VeinWares.SubtleByte/VeinWares.SubtleByte.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68fe5ae4c75c8327955af67238a61b6f