### PR TITLE
Fix infamy persistence path fallback

### DIFF
--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyPersistence.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyPersistence.cs
@@ -18,9 +18,13 @@ internal static class FactionInfamyPersistence
         WriteIndented = true
     };
 
-    private static string ConfigDirectory => Path.Combine(Paths.ConfigPath, "VeinWares SubtleByte", "Infamy");
+    private static string BaseConfigPath => string.IsNullOrWhiteSpace(Paths.ConfigPath)
+        ? Path.Combine("BepInEx", "config")
+        : Paths.ConfigPath;
+
+    private static string ConfigDirectory => Path.Combine(BaseConfigPath, "VeinWares SubtleByte", "Infamy");
     private static string SavePath => Path.Combine(ConfigDirectory, "playerInfamyLevel.json");
-    private static string LegacySavePath => Path.Combine(Paths.ConfigPath, "VeinWares SubtleByte", "playerInfamyLevel.json");
+    private static string LegacySavePath => Path.Combine(BaseConfigPath, "VeinWares SubtleByte", "playerInfamyLevel.json");
 
     public static Dictionary<ulong, PlayerHateData> Load()
     {


### PR DESCRIPTION
## Summary
- add a fallback base path for the faction infamy persistence layer when `Paths.ConfigPath` is null or empty
- ensure both primary and legacy save locations use the resolved base path so autosaves can execute

## Testing
- `dotnet build VeinWares.SubtleByte/VeinWares.SubtleByte.csproj` *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_6906351981f88327bd0c2c2b57cc51fd