### PR TITLE
Improve infamy persistence path resolution fallback

### DIFF
--- a/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyPersistence.cs
+++ b/VeinWares.SubtleByte/Services/FactionInfamy/FactionInfamyPersistence.cs
@@ -18,9 +18,73 @@ internal static class FactionInfamyPersistence
         WriteIndented = true
     };
 
-    private static string ConfigDirectory => Path.Combine(Paths.ConfigPath, "VeinWares SubtleByte", "Infamy");
+    private static readonly object PathResolutionLock = new();
+    private static string? _baseConfigPath;
+
+    private static string BaseConfigPath
+    {
+        get
+        {
+            if (_baseConfigPath is not null)
+            {
+                return _baseConfigPath;
+            }
+
+            lock (PathResolutionLock)
+            {
+                if (_baseConfigPath is null)
+                {
+                    _baseConfigPath = ResolveBaseConfigPath();
+                }
+
+                return _baseConfigPath;
+            }
+        }
+    }
+
+    private static string ConfigDirectory => Path.Combine(BaseConfigPath, "VeinWares SubtleByte", "Infamy");
     private static string SavePath => Path.Combine(ConfigDirectory, "playerInfamyLevel.json");
-    private static string LegacySavePath => Path.Combine(Paths.ConfigPath, "VeinWares SubtleByte", "playerInfamyLevel.json");
+    private static string LegacySavePath => Path.Combine(BaseConfigPath, "VeinWares SubtleByte", "playerInfamyLevel.json");
+
+    private static string ResolveBaseConfigPath()
+    {
+        if (!string.IsNullOrWhiteSpace(Paths.ConfigPath))
+        {
+            return NormalizePath(Paths.ConfigPath);
+        }
+
+        if (!string.IsNullOrWhiteSpace(Paths.BepInExRootPath))
+        {
+            var candidate = Path.Combine(Paths.BepInExRootPath, "config");
+            ModLogger.Warn($"[InfamyPersistence] Paths.ConfigPath was empty; using BepInEx root fallback: {candidate}");
+            return NormalizePath(candidate);
+        }
+
+        var baseDirectory = AppContext.BaseDirectory;
+        if (!string.IsNullOrWhiteSpace(baseDirectory))
+        {
+            var candidate = Path.Combine(baseDirectory, "BepInEx", "config");
+            ModLogger.Warn($"[InfamyPersistence] Paths.ConfigPath was empty; using application base directory fallback: {candidate}");
+            return NormalizePath(candidate);
+        }
+
+        var processDirectory = Environment.CurrentDirectory;
+        var fallback = Path.Combine(processDirectory, "BepInEx", "config");
+        ModLogger.Warn($"[InfamyPersistence] Falling back to process directory for config path: {fallback}");
+        return NormalizePath(fallback);
+    }
+
+    private static string NormalizePath(string path)
+    {
+        try
+        {
+            return Path.GetFullPath(path);
+        }
+        catch
+        {
+            return path;
+        }
+    }
 
     public static Dictionary<ulong, PlayerHateData> Load()
     {


### PR DESCRIPTION
## Summary
- cache the resolved infamy persistence config path and derive it from multiple fallbacks when `Paths.ConfigPath` is unavailable
- normalize the resolved directory to an absolute location and log the selected fallback so saves land in a stable location

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_6906351981f88327bd0c2c2b57cc51fd